### PR TITLE
Don't pass super version of attribute if it doesn't exist

### DIFF
--- a/channel/output.nix
+++ b/channel/output.nix
@@ -167,7 +167,7 @@ let
     recurse = true;
     deepOverride = a: b: b;
     path = [ ];
-    packageScope = super: pname: scope // { ${pname} = super.${pname}; };
+    packageScope = super: pname: scope // lib.optionalAttrs (super ? ${pname}) { ${pname} = super.${pname}; };
     funs = packageSetFuns "toplevel" "pkgs";
   };
 
@@ -215,7 +215,7 @@ let
             # TODO: Probably more efficient to directly inspect function arguments and fill these entries out.
             # A callPackage abstraction that allows specifying multiple attribute sets might be nice
             packageScope = super: pname:
-              scope // {
+              scope // lib.optionalAttrs (super ? ${pname}) {
                 ${pname} = super.${pname};
                 ${spec.callScopeAttr} = packageSetScope // {
                   ${pname} = super.${pname};


### PR DESCRIPTION
This is necessary for packages that aren't defined in nixpkgs already. Not yet fully tested, and will have to add a test to prevent regressions of this.

<!--

Thank you for your contribution!

To keep this project of high quality, please make sure to tick all the
following boxes before sending your pull request.

Your pull request will automatically have its tests run and spelling checked,
but if you would like to run these checks locally, you can do so:

Run your tests locally with:

    nix-build channel/tests && ./result
    nix-build tests && ./result

Check the spelling of your documentation with codespell:

    git ls-files | nix-shell -p findutils codespell --run "xargs codespell -q 2"

Reformat your changes with nixfmt:

    git ls-files | grep '.nix$' | nix-shell -p findutils nixfmt --run "xargs nixfmt"

-->

- [ ] I have created a test to cover the new behavior.
- [ ] I have written and updated relevant documentation, including updating this
      pull request template if necessary. Note that we try to follow the
      [Divio documentation](https://documentation.divio.com/) of documentation.

