### PR TITLE
Nixexprs renaming, channel name detection for arbitrary hosts, and absolute nix path for tests

### DIFF
--- a/channel/nameFromGit.nix
+++ b/channel/nameFromGit.nix
@@ -49,23 +49,23 @@ let
     result = { };
   } lines).result;
 
-  nixexprsRemotes = let
+  floxpkgsRemotes = let
     remotes = lib.attrValues (sections.remote or { });
 
-    parseNixexprsUrl = remote:
+    parseFloxpkgsUrl = remote:
       let
-        m = builtins.match ".*github.com[:/](.*)/nixexprs(\\.git)?"
+        m = builtins.match ".*github.com[:/](.*)/floxpkgs(\\.git)?"
           (remote.url or "");
       in if m == null then m else lib.elemAt m 0;
 
-  in lib.unique (lib.filter (m: m != null) (map parseNixexprsUrl remotes));
+  in lib.unique (lib.filter (m: m != null) (map parseFloxpkgsUrl remotes));
 
-  result = if lib.length nixexprsRemotes == 0 then {
-    failure = "No nixexprs remotes found in Git config";
-  } else if lib.length nixexprsRemotes == 1 then {
-    success = lib.elemAt nixexprsRemotes 0;
+  result = if lib.length floxpkgsRemotes == 0 then {
+    failure = "No floxpkgs remotes found in Git config";
+  } else if lib.length floxpkgsRemotes == 1 then {
+    success = lib.elemAt floxpkgsRemotes 0;
   } else {
-    failure = "Multiple nixexprs remotes found in Git config";
+    failure = "Multiple floxpkgs remotes found in Git config";
   };
 
 in if exists then

--- a/channel/nameFromGit.nix
+++ b/channel/nameFromGit.nix
@@ -53,9 +53,7 @@ let
     remotes = lib.attrValues (sections.remote or { });
 
     parseFloxpkgsUrl = remote:
-      let
-        m = builtins.match ".*github.com[:/](.*)/floxpkgs(\\.git)?"
-          (remote.url or "");
+      let m = builtins.match ".*[:/](.*)/floxpkgs(\\.git)?" (remote.url or "");
       in if m == null then m else lib.elemAt m 0;
 
   in lib.unique (lib.filter (m: m != null) (map parseFloxpkgsUrl remotes));

--- a/channel/output.nix
+++ b/channel/output.nix
@@ -300,7 +300,7 @@ let
             (createSet spec.name superSet spec.packageScope spec.funs.deep));
       in mergeSets (map deepOverlaySet deepOutputSpecs);
 
-    # See https://github.com/flox/nixexprs/blob/staging/docs/expl/deep-overrides.md#channel-dependencies for why this order seems to be reversed
+    # See https://github.com/flox/floxpkgs/blob/staging/docs/expl/deep-overrides.md#channel-dependencies for why this order seems to be reversed
   in lib.optional (deepOutputSpecs != [ ]) deepOverlay ++ myArgs.extraOverlays
   ++ parentOverlays;
 

--- a/channel/package-sets.nix
+++ b/channel/package-sets.nix
@@ -90,7 +90,7 @@ in lib.mapAttrs packageSet {
        The standard attribute that callPackage passes the package files as an argument for finding the package set
      - deepOverride :: PackageSet -> PackageSet
        Takes two package sets and deeply overrides the former to use all dependencies from the latter
-       See https://github.com/flox/nixexprs/blob/staging/docs/expl/deep-overrides.md#package-sets for why this is needed
+       See https://github.com/flox/floxpkgs/blob/staging/docs/expl/deep-overrides.md#package-sets for why this is needed
   */
 
   haskell = {

--- a/channel/tests/name-gitConfig/config.nix
+++ b/channel/tests/name-gitConfig/config.nix
@@ -5,12 +5,12 @@ let
   } ''
     cp -r --no-preserve=mode ${./channels/test} $out
     git -C $out init
-    git -C $out remote add real1 git@github.com:test/nixexprs.git
-    git -C $out remote add real2 https://github.com/test/nixexprs.git
-    git -C $out remote add real3 git@github.com:test/nixexprs
-    git -C $out remote add real4 https://github.com/test/nixexprs
-    git -C $out remote add fake1 git@github.com:foo/nixexprs-not.git
-    git -C $out remote add fake2 git@github.com:foo/not-nixexprs.git
+    git -C $out remote add real1 git@github.com:test/floxpkgs.git
+    git -C $out remote add real2 https://github.com/test/floxpkgs.git
+    git -C $out remote add real3 git@github.com:test/floxpkgs
+    git -C $out remote add real4 https://github.com/test/floxpkgs
+    git -C $out remote add fake1 git@github.com:foo/floxpkgs-not.git
+    git -C $out remote add fake2 git@github.com:foo/not-floxpkgs.git
   '';
 in {
   type = "eval";

--- a/channel/tests/name-unknown/stderr
+++ b/channel/tests/name-unknown/stderr
@@ -1,5 +1,5 @@
 trace: warning: Channel name could not be inferred because all heuristics failed:
-- chanArgs: No "name" defined in the nixexprs default.nix
+- chanArgs: No "name" defined in the floxpkgs default.nix
 - cmdArgs: No "name" passed with `--argstr name <channel name>`
 - nixPath: No entries in NIX_PATH match path /nix/store/.*-test
 - baseName: topdir is in /nix/store, basename is nonsensical

--- a/docs/expl/deep-overrides.md
+++ b/docs/expl/deep-overrides.md
@@ -1,6 +1,6 @@
 # How deep overrides work
 
-Flox channels have support for [defining packages as deep-overriding](../channel-construction.md#shallow-vs-deep-overriding). While the interface to this feature is really simple, [the implementation](https://github.com/flox/nixexprs/blob/staging/channel/output.nix) is very tricky.
+Flox channels have support for [defining packages as deep-overriding](../channel-construction.md#shallow-vs-deep-overriding). While the interface to this feature is really simple, [the implementation](https://github.com/flox/floxpkgs/blob/staging/channel/output.nix) is very tricky.
 
 The underlying mechanism that allows this feature to work are [nixpkgs overlays](https://nixos.org/manual/nixpkgs/stable/#sec-overlays-definition). Packages that specify themselves as deep-overriding are injected into nixpkgs with an overlay. For top-level packages in `pkgs/<name>` this is very easy with an overlay like
 

--- a/docs/expl/name-inference.md
+++ b/docs/expl/name-inference.md
@@ -15,7 +15,7 @@ import <flox/channel> {
 }
 ```
 
-This is however not ideal for getting started, since the [nixexprs template](https://github.com/flox/nixexprs-template) won't be able to fill this out, meaning users would have to edit `default.nix` manually before starting. By inferring the name automatically, this initial step is not necessary anymore.
+This is however not ideal for getting started, since the [floxpkgs template](https://github.com/flox/floxpkgs-template) won't be able to fill this out, meaning users would have to edit `default.nix` manually before starting. By inferring the name automatically, this initial step is not necessary anymore.
 
 ## Why the channel name is needed at all
 
@@ -42,8 +42,8 @@ By knowing that the channel we're evaluating is `A`, we can override the path fo
 ## Why it's so complicated
 
 Channel name inference is not trivial however: The only information that the `<flox/channel>` function gets is the `topdir` value. Since there's a variety of ways in which the channel can be evaluated, a number of heuristics are used to try to infer the name:
-- By looking at the base name of the topdir: This is the easiest way to infer the name in cases where the directory name is the same as the channel. This won't trigger when the base name is just "nixexprs" however, which is the standard name git would name it when cloning.
-- By looking at the git remotes in the git config: In case the nixexprs repository is a git checkout, this is very reliable
+- By looking at the base name of the topdir: This is the easiest way to infer the name in cases where the directory name is the same as the channel. This won't trigger when the base name is just "floxpkgs" however, which is the standard name git would name it when cloning.
+- By looking at the git remotes in the git config: In case the floxpkgs repository is a git checkout, this is very reliable
 - By trying to find `topdir` in `NIX_PATH`: Since all channels are passed via `NIX_PATH`, there's a good chance some entry in there points at it. The value of that entry is the channel name. There is a problem with this heuristic however: If a `NIX_PATH` entry points `<myChan>` to `/some/path`, and `/some/path` is a symlink, then `topdir` will point to the _target_ of the symlink, while the `NIX_PATH` entry points to the _source_ of it, so it can't match them together. And there is no way to resolve symlinks in Nix.
 
 In addition, channel inference handles different casings: GitHub usernames, and therefore `NIX_PATH` channel entries, are case-insensitive, but case-preserving. So if any channel inference mechanism finds a match, it looks at all the entries in `NIX_PATH` to correct the casing if necessary.

--- a/docs/package-sets.md
+++ b/docs/package-sets.md
@@ -2,7 +2,7 @@
 
 Package sets are collections of packages/libraries for a specific programming language. E.g. a python package set defines a set of python packages that can be used to build python applications. These packages are often specific to a certain version of the language, meaning there are different package sets for different versions.
 
-Nixexprs channels however support defining packages for version-agnostic package sets. Declaring such packages defines them for all supported package set versions at once. A version is only supported if nixpkgs supports it. In such version-agnostic package declarations, you need to make sure to use version-agnostic references to other packages in the same package set in order to avoid mixing versions.
+Floxpkgs channels however support defining packages for version-agnostic package sets. Declaring such packages defines them for all supported package set versions at once. A version is only supported if nixpkgs supports it. In such version-agnostic package declarations, you need to make sure to use version-agnostic references to other packages in the same package set in order to avoid mixing versions.
 
 See [package-sets.nix](../channel/package-sets.nix) to see how package sets are defined to support this, or to see how more package sets can be added.
 

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -54,6 +54,8 @@ let
         eval-json = "nix-instantiate --eval --strict --json";
       }.${config.type} or (throw "No such type ${config.type}");
 
+      binary = "${lib.getBin pkgs.nix}/bin/${base}";
+
       nixPath = "NIX_PATH=${lib.escapeShellArg (createNixPath config.nixPath)}";
 
       args = lib.mapAttrsToList (name: value:
@@ -63,9 +65,8 @@ let
       options = lib.mapAttrsToList (name: value:
         "--option ${lib.escapeShellArg name} ${lib.escapeShellArg value}")
         config.nixOptions;
-    in "${nixPath} ${base} ${config.file} ${lib.concatStringsSep " " args} ${
-      lib.concatStringsSep " " options
-    }";
+      parts = [ nixPath binary config.file ] ++ args ++ options;
+    in lib.concatStringsSep " " parts;
 
   # Returns a script that runs a test. Assumes a usable nix is in PATH
   testScript = name: path:


### PR DESCRIPTION
Does three barely-related things:
- With the recent name switch from "nixexprs" to "floxpkgs", the channel name detection via the git config doesn't work anymore, since that worked under the assumption that the repository might be named nixexprs. The first commit fixes that by rewriting all "nixexprs" strings to "floxpkgs" ones
- The second commit makes the git remote detection work for non-github.com hosts, useful for enterprise github deployments
- The third commit just makes tests resilient against having an unstable Nix in path by using an absolute path instead.

- [ ] I have created a test to cover the new behavior.
- [ ] I have written and updated relevant documentation, including updating this
      pull request template if necessary. Note that we try to follow the
      [Divio documentation](https://documentation.divio.com/) of documentation.

