### PR TITLE
Fix `buildErlangMk` builder

### DIFF
--- a/beamPackages/buildErlangMk.nix
+++ b/beamPackages/buildErlangMk.nix
@@ -3,11 +3,10 @@
 # from metadata cached by the nixpkgs mechanism.
 
 # Arguments provided to callPackage().
-{ lib, beam, erlangR18, meta, ... }:
+{ lib, beamPackages, meta, ... }:
 
 # Arguments provided to flox.mkDerivation()
 { project # the name of the project, required
-, erlang ? erlangR18, beamPackages ? beam.packages.erlangR18
 , nativeBuildInputs ? [ ], ... }@args:
 let
   source = meta.getBuilderSource project args;


### PR DESCRIPTION
Two fixes:
- Prevent package set attributes from overriding the `meta` argument. This caused problems with an erlang package named `meta`
- Fix infinite recursion with `mkErlangMk` builder, caused by it referring to itself

I had a go at creating a test for an erlang package, but I couldn't do it in a reasonable time due to my unfamiliarity with Erlang.

- [ ] I have created a test to cover the new behavior.
- [ ] I have written and updated relevant documentation, including updating this
      pull request template if necessary. Note that we try to follow the
      [Divio documentation](https://documentation.divio.com/) of documentation.