### PR TITLE
Allow builders to be overridden

### DIFF
--- a/beamPackages/buildErlangMk.nix
+++ b/beamPackages/buildErlangMk.nix
@@ -7,11 +7,11 @@
 
 # Arguments provided to flox.mkDerivation()
 { project # the name of the project, required
-, nativeBuildInputs ? [ ], ... }@args:
+, channel ? meta.importingChannel, nativeBuildInputs ? [ ], ... }@args:
 let
-  source = meta.getBuilderSource project args;
+  source = meta.getChannelSource channel project args;
   # Actually create the derivation.
-in beamPackages.buildErlangMk (args // {
+in beamPackages.buildErlangMk (removeAttrs args [ "channel" ] // {
   # build-erlang-mk.nix re-appends the version to the name,
   # so we need to not inherit name and instead pass what we
   # call "pname" as "name".

--- a/channel/getSource.nix
+++ b/channel/getSource.nix
@@ -1,20 +1,12 @@
-{ sourceOverrides, channel, lib, fetchgit, buildPackages }:
-# Set the src and version variables based on project.
-# Recall that flox calls this expression with --argstr sourceOverrideJson '{ ... }',
-# so that needs to take precedence over all other sources of src.
-project: overrides:
+{ sourceOverrides, lib, fetchgit, buildPackages }:
+channel:
 let
-
   channelSourceOverrides = sourceOverrides.${channel} or { };
-
-  # The following three definitions are three different ways of getting the
-  # source. Each of these defines an attribute set with all the info needed from
-  # the source, including:
-  # - src: The path to the source
-  # - origversion: The original version of the source
-  # - versionSuffix: An optional version suffix
-  # - extraInfo: Any additional source attributes used for identifying it
-
+  # Set the src and version variables based on project.
+  # Recall that flox calls this expression with --argstr sourceOverrideJson '{ ... }',
+  # so that needs to take precedence over all other sources of src.
+in project:
+let
   # The source is provided with `--argstr sourceOverrideJson`
   channelOverrideComponents = let
     # This fetches all uncommitted changes, without untracked files
@@ -28,6 +20,16 @@ let
     extraInfo =
       lib.optionalAttrs (src.revCount != 0) { inherit (src) rev revCount; };
   };
+in overrides:
+let
+
+  # The following three definitions are three different ways of getting the
+  # source. Each of these defines an attribute set with all the info needed from
+  # the source, including:
+  # - src: The path to the source
+  # - origversion: The original version of the source
+  # - versionSuffix: An optional version suffix
+  # - extraInfo: Any additional source attributes used for identifying it
 
   # The source is provided via the `src` argument
   argumentOverrideComponents = {

--- a/channel/output.nix
+++ b/channel/output.nix
@@ -339,15 +339,16 @@ let
       outputSpecs
     }") (mergeSets (map outputSet outputSpecs));
 
-  meta = {
-    getSource = pkgs.callPackage ./getSource.nix {
-      channel = myArgs.name;
-      inherit sourceOverrides;
-    };
-    getBuilderSource = pkgs.callPackage ./getSource.nix {
-      channel = parentArgs.name;
-      inherit sourceOverrides;
-    };
+  meta = rec {
+    getChannelSource =
+      pkgs.callPackage ./getSource.nix { inherit sourceOverrides; };
+    getSource = getChannelSource ownChannel;
+    getBuilderSource = lib.warn
+      ("meta.getBuilderSource as used by channel ${myArgs.name} is deprecated,"
+        + " use `meta.getChannelSource meta.importingChannel` instead")
+      (getChannelSource importingChannel);
+    ownChannel = myArgs.name;
+    importingChannel = parentArgs.name;
     inherit withVerbosity;
   };
 

--- a/channel/tests/flox-getBuilderSource/channels/other/pkgs/testBuilder/default.nix
+++ b/channel/tests/flox-getBuilderSource/channels/other/pkgs/testBuilder/default.nix
@@ -1,3 +1,5 @@
 { meta }:
-let mockedGetSource = meta.getBuilderSource.override { fetchgit = args: args; };
+let
+  mockedGetSource = meta.getChannelSource.override { fetchgit = args: args; }
+    meta.importingChannel;
 in { result = mockedGetSource "testPackage" { }; }

--- a/channel/tests/flox-getSource-override-branch/channels/test/pkgs/testPackage/default.nix
+++ b/channel/tests/flox-getSource-override-branch/channels/test/pkgs/testPackage/default.nix
@@ -1,6 +1,6 @@
 { flox, meta }:
 let
-  mockedGetSource = meta.getSource.override {
+  mockedGetSource = meta.getChannelSource.override {
     fetchgit = args: builtins.trace "fetchgit called" args;
-  };
+  } meta.ownChannel;
 in { result = mockedGetSource "testPackage" { rev = "alt"; }; }

--- a/channel/tests/flox-getSource-override-rev/channels/test/pkgs/testPackage/default.nix
+++ b/channel/tests/flox-getSource-override-rev/channels/test/pkgs/testPackage/default.nix
@@ -1,8 +1,8 @@
 { flox, meta }:
 let
-  mockedGetSource = meta.getSource.override {
+  mockedGetSource = meta.getChannelSource.override {
     fetchgit = args: builtins.trace "fetchgit called" args;
-  };
+  } meta.ownChannel;
 in {
   result = mockedGetSource "testPackage" {
     rev = "783f71ba9565ed912473812c5781f0a623b22fa9";

--- a/channel/tests/flox-getSource-override-src/channels/test/pkgs/testPackage/default.nix
+++ b/channel/tests/flox-getSource-override-src/channels/test/pkgs/testPackage/default.nix
@@ -1,5 +1,7 @@
 { flox, meta }:
-let mockedGetSource = meta.getSource.override { fetchgit = args: args; };
+let
+  mockedGetSource =
+    meta.getChannelSource.override { fetchgit = args: args; } meta.ownChannel;
 in {
   result = mockedGetSource "testPackage" {
     src = "/some/src/path";

--- a/channel/tests/flox-getSource-sourceOverride/channels/test/pkgs/testDep/default.nix
+++ b/channel/tests/flox-getSource-sourceOverride/channels/test/pkgs/testDep/default.nix
@@ -1,5 +1,6 @@
 { flox, meta }:
 let
   mockedGetSource =
-    meta.getSource.override { fetchgit = args: { result = "result"; }; };
+    meta.getChannelSource.override { fetchgit = args: { result = "result"; }; }
+    meta.ownChannel;
 in { result = mockedGetSource "testDep" { }; }

--- a/channel/tests/flox-getSource-sourceOverride/channels/test/pkgs/testPackage/default.nix
+++ b/channel/tests/flox-getSource-sourceOverride/channels/test/pkgs/testPackage/default.nix
@@ -1,8 +1,8 @@
 { flox, meta, testDep }:
 let
-  mockedGetSource = meta.getSource.override {
+  mockedGetSource = meta.getChannelSource.override {
     fetchgit = args: builtins.trace "fetchgit called" args;
-  };
+  } meta.ownChannel;
 in {
   result = {
     src = mockedGetSource "testPackage" { };

--- a/channel/tests/flox-getSource/channels/test/pkgs/testPackage/default.nix
+++ b/channel/tests/flox-getSource/channels/test/pkgs/testPackage/default.nix
@@ -1,6 +1,6 @@
 { flox, meta }:
 let
-  mockedGetSource = meta.getSource.override {
+  mockedGetSource = meta.getChannelSource.override {
     fetchgit = args: builtins.trace "fetchgit called" args;
-  };
+  } meta.ownChannel;
 in { result = mockedGetSource "testPackage" { }; }

--- a/docs/builders.md
+++ b/docs/builders.md
@@ -22,8 +22,10 @@ Creates a package using nixpkgs standard environment builder. Use this for C/C++
 **For files:** `pkgs/<name>/default.nix`
 
 #### Inputs
-- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this package. This is passed as the `<project>` argument to `meta.getBuilderSource`.
-- All other arguments are passed as the `<overrides>` argument to `meta.getBuilderSource`. See [its documentation](channel-construction.md#getbuildersource-project-overrides) for how the source can be influenced with this.
+- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this package. This is passed as the [`<project>` argument](./channel-construction.md#argument-project-string) to `meta.getChannelSource`.
+- `channel` (string, optional, default [`meta.importingChannel`](./channel-construction.md#importingchannel)): The name of the channel, aka GitHub user/organization to get the `<project>` from. Defaults to the channel that uses/imports this builder. This is passed as the [`<channel>` argument](./channel-construction.md#argument-channel-string) to `meta.getChannelSource`.
+The name of the GitHub repository in your organization to use as the source of this package. This is passed as the [`<project>` argument](./channel-construction.md#argument-project-string) to `meta.getChannelSource`.
+- All other arguments are passed as the [`<overrides>` argument](./channel-construction.md#argument-overrides-string) to `meta.getChannelSource`. See [its documentation](channel-construction.md#getchannelsource-channel-project-overrides) for how the source can be influenced with this.
 - All other arguments are also passed to nixpkgs `stdenv.mkDerivation` function. Refer to the [standard environment documentation](https://nixos.org/manual/nixpkgs/stable/#chap-stdenv) for more information. The most important arguments are:
   - `buildInputs` (list of packages, default `[]`): Package dependencies, e.g. dynamic libraries
   - `nativeBuildInputs` (list of packages, default `[]`): Build-time dependencies, such as e.g. `cmake` or `pkg-config`
@@ -45,8 +47,9 @@ Creates a Python package from an auto-updating reference to a repository.
 **For files:** `pythonPackages/<name>/default.nix`
 
 #### Inputs
-- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this Python package. This is passed as the `<project>` argument to `meta.getBuilderSource`.
-- All other arguments are passed as the `<overrides>` argument to `meta.getBuilderSource`. See [its documentation](channel-construction.md#getbuildersource-project-overrides) for how the source can be influenced with this.
+- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this package. This is passed as the [`<project>` argument](./channel-construction.md#argument-project-string) to `meta.getChannelSource`.
+- `channel` (string, optional, default [`meta.importingChannel`](./channel-construction.md#importingchannel)): The name of the channel, aka GitHub user/organization to get the `<project>` from. Defaults to the channel that uses/imports this builder. This is passed as the [`<channel>` argument](./channel-construction.md#argument-channel-string) to `meta.getChannelSource`.
+- All other arguments are passed as the [`<overrides>` argument](./channel-construction.md#argument-overrides-string) to `meta.getChannelSource`. See [its documentation](channel-construction.md#getchannelsource-channel-project-overrides) for how the source can be influenced with this.
 - All other arguments are also passed to nixpkgs `pythonPackages.buildPythonPackage` function. Refer to [its full documentation](https://nixos.org/manual/nixpkgs/stable/#buildpythonpackage-function) for more information. The most important arguments are:
   - `propagatedBuildInputs` (list of Python package derivations, default `[]`): Python runtime dependencies
   - `checkInputs` (list of Python package derivations, default `[]`): Python test dependencies
@@ -95,8 +98,9 @@ Creates a Perl package or application from an auto-updating reference to a repos
 **For files:** `perlPackages/<name>/default.nix` for packages or `pkgs/<name>/default.nix` for applications
 
 #### Inputs
-- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this Perl package. This is passed as the `<project>` argument to `meta.getBuilderSource`.
-- All other arguments are passed as the `<overrides>` argument to `meta.getBuilderSource`. See [its documentation](channel-construction.md#getbuildersource-project-overrides) for how the source can be influenced with this.
+- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this package. This is passed as the [`<project>` argument](./channel-construction.md#argument-project-string) to `meta.getChannelSource`.
+- `channel` (string, optional, default [`meta.importingChannel`](./channel-construction.md#importingchannel)): The name of the channel, aka GitHub user/organization to get the `<project>` from. Defaults to the channel that uses/imports this builder. This is passed as the [`<channel>` argument](./channel-construction.md#argument-channel-string) to `meta.getChannelSource`.
+- All other arguments are passed as the [`<overrides>` argument](./channel-construction.md#argument-overrides-string) to `meta.getChannelSource`. See [its documentation](channel-construction.md#getchannelsource-channel-project-overrides) for how the source can be influenced with this.
 - All other arguments are also passed to nixpkgs `perlPackages.buildPerlPackage` function. Refer to [nixpkgs Perl packaging documentation](https://nixos.org/manual/nixpkgs/stable/#ssec-perl-packaging) for more information. The most important arguments are:
   - `propagatedBuildInputs` (list of Perl package derivations, default `[]`): Perl dependencies
 
@@ -125,12 +129,13 @@ Creates a Go application from an auto-updating reference to a repository using G
 **For files:** `pkgs/<name>/default.nix`
 
 #### Inputs
-- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this Go application. This is passed as the `<project>` argument to `meta.getBuilderSource`.
+- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this package. This is passed as the [`<project>` argument](./channel-construction.md#argument-project-string) to `meta.getChannelSource`.
   - The project version can be accessed from Go code by adding the following to the `main` package:
     ```go
     var nixVersion string
     ```
-- All other arguments are passed as the `<overrides>` argument to `meta.getBuilderSource`. See [its documentation](channel-construction.md#getbuildersource-project-overrides) for how the source can be influenced with this.
+- `channel` (string, optional, default [`meta.importingChannel`](./channel-construction.md#importingchannel)): The name of the channel, aka GitHub user/organization to get the `<project>` from. Defaults to the channel that uses/imports this builder. This is passed as the [`<channel>` argument](./channel-construction.md#argument-channel-string) to `meta.getChannelSource`.
+- All other arguments are passed as the [`<overrides>` argument](./channel-construction.md#argument-overrides-string) to `meta.getChannelSource`. See [its documentation](channel-construction.md#getchannelsource-channel-project-overrides) for how the source can be influenced with this.
 - All other arguments are also passed to nixpkgs `buildGoModule` function. Refer to [its documentation](https://nixos.org/manual/nixpkgs/stable/#ssec-go-modules) for more information. The most important arguments are:
   - `vendorSha256` (string or null, mandatory): The hash of all the dependencies, or `null` if the package vendors dependencies. Since this hash is not known beforehand, a fake hash like `lib.fakeSha256` must be used at first to get the correct hash with the first failing build.
 
@@ -152,12 +157,13 @@ Creates a Go application from an auto-updating reference to a repository. Can be
 **For files:** `pkgs/<name>/default.nix`
 
 #### Inputs
-- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this Go application. This is passed as the `<project>` argument to `meta.getBuilderSource`.
+- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this package. This is passed as the [`<project>` argument](./channel-construction.md#argument-project-string) to `meta.getChannelSource`.
   - The project version can be accessed from Go code by adding the following to the `main` package:
     ```go
     var nixVersion string
     ```
-- All other arguments are passed as the `<overrides>` argument to `meta.getBuilderSource`. See [its documentation](channel-construction.md#getbuildersource-project-overrides) for how the source can be influenced with this.
+- `channel` (string, optional, default [`meta.importingChannel`](./channel-construction.md#importingchannel)): The name of the channel, aka GitHub user/organization to get the `<project>` from. Defaults to the channel that uses/imports this builder. This is passed as the [`<channel>` argument](./channel-construction.md#argument-channel-string) to `meta.getChannelSource`.
+- All other arguments are passed as the [`<overrides>` argument](./channel-construction.md#argument-overrides-string) to `meta.getChannelSource`. See [its documentation](channel-construction.md#getchannelsource-channel-project-overrides) for how the source can be influenced with this.
 - All other arguments are also passed to nixpkgs `buildGoPackage` function. Refer to [its documentation](https://nixos.org/manual/nixpkgs/stable/#ssec-go-legacy) for more information. The most important arguments are:
   - `goPackagePath` (string, mandatory): The package's canonical Go import path.
   - `goDeps` (path, mandatory): Path to `deps.nix` file containing package dependencies. For a project using Go modules, this can be generated with [vgo2nix](https://github.com/nix-community/vgo2nix), for other projects [go2nix](https://github.com/kamilchm/go2nix) can be used.
@@ -180,8 +186,9 @@ Creates a Rust application from an auto-updating reference to a repository.
 **For files:** `pkgs/<name>/default.nix`
 
 #### Inputs
-- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this Rust application. This is passed as the `<project>` argument to `meta.getBuilderSource`.
-- All other arguments are passed as the `<overrides>` argument to `meta.getBuilderSource`. See [its documentation](channel-construction.md#getbuildersource-project-overrides) for how the source can be influenced with this.
+- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this package. This is passed as the [`<project>` argument](./channel-construction.md#argument-project-string) to `meta.getChannelSource`.
+- `channel` (string, optional, default [`meta.importingChannel`](./channel-construction.md#importingchannel)): The name of the channel, aka GitHub user/organization to get the `<project>` from. Defaults to the channel that uses/imports this builder. This is passed as the [`<channel>` argument](./channel-construction.md#argument-channel-string) to `meta.getChannelSource`.
+- All other arguments are passed as the [`<overrides>` argument](./channel-construction.md#argument-overrides-string) to `meta.getChannelSource`. See [its documentation](channel-construction.md#getchannelsource-channel-project-overrides) for how the source can be influenced with this.
 - All other arguments are also passed to nixpkgs `rustPlatform.buildRustPackage` function. Refer to [its documentation](https://nixos.org/manual/nixpkgs/stable/#compiling-rust-applications-with-cargo) for more information. One of the following arguments is needed for specifying the dependencies:
   - `cargoSha256` (string): The hash of all dependencies. Since this hash is not known beforehand, a fake hash like `lib.fakeSha256` must be used at first to get the correct hash with the first failing build.
   - `cargoVendorDir` (path): An alternative to `cargoSha256`, which can be used if dependencies are vendored with `cargo vendor`. Pass the path to the `vendor` directory with this option.
@@ -204,8 +211,9 @@ Creates a Rust application from an auto-updating reference to a repository. Simi
 **For files:** `pkgs/<name>/default.nix`
 
 #### Inputs
-- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this Rust application. This is passed as the `<project>` argument to `meta.getBuilderSource`.
-- All other arguments are passed as the `<overrides>` argument to `meta.getBuilderSource`. See [its documentation](channel-construction.md#getbuildersource-project-overrides) for how the source can be influenced with this.
+- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this package. This is passed as the [`<project>` argument](./channel-construction.md#argument-project-string) to `meta.getChannelSource`.
+- `channel` (string, optional, default [`meta.importingChannel`](./channel-construction.md#importingchannel)): The name of the channel, aka GitHub user/organization to get the `<project>` from. Defaults to the channel that uses/imports this builder. This is passed as the [`<channel>` argument](./channel-construction.md#argument-channel-string) to `meta.getChannelSource`.
+- All other arguments are passed as the [`<overrides>` argument](./channel-construction.md#argument-overrides-string) to `meta.getChannelSource`. See [its documentation](channel-construction.md#getchannelsource-channel-project-overrides) for how the source can be influenced with this.
 - All other arguments are also passed to naersk. Refer to [its documentation](https://github.com/nmattia/naersk#configuration) for more information.
 
 Notice the lack of a mandatory `cargoSha256`-like argument. This is because naersk extracts the hash from your Cargo.lock file.
@@ -228,8 +236,9 @@ Creates a Haskell package or application from an auto-updating reference to a re
 **For files:** `haskellPackages/<name>/default.nix` for packages or `pkgs/<name>/default.nix` for applications
 
 #### Inputs
-- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this Haskell package. This is passed as the `<project>` argument to `meta.getBuilderSource`.
-- All other arguments are passed as the `<overrides>` argument to `meta.getBuilderSource`. See [its documentation](channel-construction.md#getbuildersource-project-overrides) for how the source can be influenced with this.
+- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this package. This is passed as the [`<project>` argument](./channel-construction.md#argument-project-string) to `meta.getChannelSource`.
+- `channel` (string, optional, default [`meta.importingChannel`](./channel-construction.md#importingchannel)): The name of the channel, aka GitHub user/organization to get the `<project>` from. Defaults to the channel that uses/imports this builder. This is passed as the [`<channel>` argument](./channel-construction.md#argument-channel-string) to `meta.getChannelSource`.
+- All other arguments are passed as the [`<overrides>` argument](./channel-construction.md#argument-overrides-string) to `meta.getChannelSource`. See [its documentation](channel-construction.md#getchannelsource-channel-project-overrides) for how the source can be influenced with this.
 - All other arguments are also passed to nixpkgs `haskellPackages.mkDerivation` function. Refer to [its source](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/generic-builder.nix) for more information. The most important arguments are:
   - `isExecutable` (boolean, default `false`): Turn this on if the package is an application and lives in `pkgs/<name>/default.nix`.
   - `buildDepends` (list of Haskell packages, default `[]`): The dependencies of this package
@@ -259,8 +268,9 @@ Creates an Erlang package or application from an auto-updating reference to a re
 **For files:** `beamPackages/<name>/default.nix` for packages or `pkgs/<name>/default.nix` for applications
 
 #### Inputs
-- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this Erlang package. This is passed as the `<project>` argument to `meta.getBuilderSource`.
-- All other arguments are passed as the `<overrides>` argument to `meta.getBuilderSource`. See [its documentation](channel-construction.md#getbuildersource-project-overrides) for how the source can be influenced with this.
+- `project` (string, mandatory): The name of the GitHub repository in your organization to use as the source of this package. This is passed as the [`<project>` argument](./channel-construction.md#argument-project-string) to `meta.getChannelSource`.
+- `channel` (string, optional, default [`meta.importingChannel`](./channel-construction.md#importingchannel)): The name of the channel, aka GitHub user/organization to get the `<project>` from. Defaults to the channel that uses/imports this builder. This is passed as the [`<channel>` argument](./channel-construction.md#argument-channel-string) to `meta.getChannelSource`.
+- All other arguments are passed as the [`<overrides>` argument](./channel-construction.md#argument-overrides-string) to `meta.getChannelSource`. See [its documentation](channel-construction.md#getchannelsource-channel-project-overrides) for how the source can be influenced with this.
 - All other arguments are also passed to nixpkgs `beamPackages.buildErlangMk` function. Refer to [its source](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/beam-modules/build-erlang-mk.nix) for more information. The most important arguments are:
   - `beamDeps` (list of beam packages, default `[]`): The Erlang dependencies of this package
 

--- a/docs/channel-construction.md
+++ b/docs/channel-construction.md
@@ -76,13 +76,17 @@ In addition, for all package sets in [above table](#subdirectories) that have a 
 
 ### Meta set
 
-#### `getSource <project> <overrides>`
+#### `getChannelSource <channel> <project> <overrides>`
 
-Gets an auto-updating reference to GitHub repository `<project>` of the current channel, allowing certain overrides of behavior with the `<overrides>` argument.
+Gets an auto-updating reference to GitHub repository `<project>` of the channel `<channel>` (aka the GitHub owner/organization), allowing certain overrides of behavior with the `<overrides>` argument.
+
+##### Argument `<channel>` (string)
+
+The channel/owner to get the source for.
 
 ##### Argument `<project>` (string)
 
-The project/repository to get the source for
+The project/repository to get the source for.
 
 ##### Argument `<overrides>` (attribute set)
 
@@ -106,11 +110,17 @@ An attribute set with attributes:
   - `system` is an additional property, currently referring to the eval time system, such as `x86_64-linux`
   - `buildDate` is a ISO8601 date string of the time that the derivation was built
 
-#### `getBuilderSource <project> <overrides>`
+#### `ownChannel`
 
-Gets an auto-updating reference to GitHub repository `<project>` of the _importing_ channel, allowing certain overrides of behavior with the `<overrides>` argument. Since this gets sources from the channel that imports this one, it is useful for declaring custom builders.
+The name of the own channel. May be `_unknown` in case the channel name couldn't be determined, see [channel name inference](./expl/name-inference.md).
 
-See [`getSource`](#getsource-project-overrides) for details on arguments and return value.
+#### `importingChannel`
+
+The channel from which this channel is accessed. In case this channel is accessed from itself, this is the same as [`ownChannel`](#ownChannel).
+
+#### `getSource <project> <overrides>`
+
+Like [`getChannelSource`](#getChannelSource-channel-project-overrides), but with [`ownChannel`](#ownChannel) passed as the `<channel>` argument.
 
 #### `withVerbosity <verbosity> <fun> <arg>`
 

--- a/haskellPackages/mkDerivation.nix
+++ b/haskellPackages/mkDerivation.nix
@@ -1,10 +1,10 @@
 { mkDerivation, lib, meta }:
 
 { project # the name of the project, required
-, ... }@args:
+, channel ? meta.importingChannel, ... }@args:
 
-let source = meta.getBuilderSource project args;
-in mkDerivation (removeAttrs args [ "project" ] // {
+let source = meta.getChannelSource channel project args;
+in mkDerivation (removeAttrs args [ "project" "channel" ] // {
   inherit (source) pname version src;
 
   # We can't set the position because mkDerivation doesn't pass on extra attributes to stdenv.mkDerivation

--- a/perlPackages/buildPerlPackage.nix
+++ b/perlPackages/buildPerlPackage.nix
@@ -7,11 +7,11 @@
 
 # Arguments provided to flox.mkDerivation()
 { project # the name of the project, required
-, ... }@args:
+, channel ? meta.importingChannel, ... }@args:
 let
-  source = meta.getBuilderSource project args;
+  source = meta.getChannelSource channel project args;
   # Actually create the derivation.
-in buildPerlPackage (args // {
+in buildPerlPackage (removeAttrs args [ "channel" ] // {
   inherit (source) version src pname;
 
   # This for one sets meta.position to where the project is defined

--- a/pkgs/buildGoModule.nix
+++ b/pkgs/buildGoModule.nix
@@ -7,11 +7,11 @@
 
 # Arguments provided to flox.mkDerivation()
 { project # the name of the project, required
-, ... }@args:
+, channel ? meta.importingChannel, ... }@args:
 let
-  source = meta.getBuilderSource project args;
+  source = meta.getChannelSource channel project args;
   # Actually create the derivation.
-in buildGoModule (args // rec {
+in buildGoModule (removeAttrs args [ "channel" ] // rec {
   inherit (source) version src name;
 
   # This for one sets meta.position to where the project is defined

--- a/pkgs/buildGoPackage.nix
+++ b/pkgs/buildGoPackage.nix
@@ -7,11 +7,11 @@
 
 # Arguments provided to flox.mkDerivation()
 { project # the name of the project, required
-, ... }@args:
+, channel ? meta.importingChannel, ... }@args:
 let
-  source = meta.getBuilderSource project args;
+  source = meta.getChannelSource channel project args;
   # Actually create the derivation.
-in buildGoPackage (args // rec {
+in buildGoPackage (removeAttrs args [ "channel" ] // rec {
   inherit (source) version src name;
 
   # This for one sets meta.position to where the project is defined

--- a/pkgs/buildRustPackage.nix
+++ b/pkgs/buildRustPackage.nix
@@ -1,7 +1,7 @@
 { rustPlatform, lib, meta }:
-{ project, ... }@args:
-let source = meta.getBuilderSource project args;
-in rustPlatform.buildRustPackage (args // rec {
+{ project, channel ? meta.importingChannel, ... }@args:
+let source = meta.getChannelSource channel project args;
+in rustPlatform.buildRustPackage (removeAttrs args [ "channel" ] // rec {
   inherit (source) pname version src;
 
   # Ensure that the cargoDeps path and checksum don't change with

--- a/pkgs/mkDerivation.nix
+++ b/pkgs/mkDerivation.nix
@@ -6,11 +6,11 @@
 
 # Arguments provided to flox.mkDerivation()
 { project # the name of the project, required
-, ... }@args:
+, channel ? meta.importingChannel, ... }@args:
 let
-  source = meta.getBuilderSource project args;
+  source = meta.getChannelSource channel project args;
   # Actually create the derivation.
-in stdenv.mkDerivation (args // {
+in stdenv.mkDerivation (removeAttrs args [ "channel" ] // {
   inherit (source) version src name;
 
   # This for one sets meta.position to where the project is defined

--- a/pkgs/naersk/buildRustPackage.nix
+++ b/pkgs/naersk/buildRustPackage.nix
@@ -1,7 +1,7 @@
 { fetchFromGitHub, callPackage, lib, meta }:
-{ project, ... }@args:
+{ project, channel ? meta.importingChannel, ... }@args:
 let
-  source = meta.getBuilderSource project args;
+  source = meta.getChannelSource channel project args;
 
   naersk = fetchFromGitHub {
     owner = "nmattia";
@@ -10,7 +10,7 @@ let
     sha256 = "09b5g2krf8mfpajgz2bgapkv3dpimg0qx1nfpjafcrsk0fhxmqay";
   };
   naersk-lib = callPackage naersk { };
-in naersk-lib.buildPackage (args // {
+in naersk-lib.buildPackage (removeAttrs args [ "channel" ] // {
   inherit (source) pname version src;
 
   # This for one sets meta.position to where the project is defined

--- a/pythonPackages/buildPythonApplication.nix
+++ b/pythonPackages/buildPythonApplication.nix
@@ -7,15 +7,15 @@
 
 # Arguments provided to flox.mkDerivation()
 { project # the name of the project, required
-, nativeBuildInputs ? [ ], ... }@args:
-let source = meta.getBuilderSource project args;
+, channel ? meta.importingChannel, nativeBuildInputs ? [ ], ... }@args:
+let source = meta.getChannelSource channel project args;
 in builtins.trace (''flox.buildPythonApplication(project="'' + project + ''", ''
   + ''python.version="'' + python.version + ''", '' + "with "
   + builtins.toString (builtins.length (builtins.attrNames pythonPackages))
   + " pythonPackages)")
 
 # Actually create the derivation.
-pythonPackages.buildPythonApplication (args // {
+pythonPackages.buildPythonApplication (removeAttrs args [ "channel" ] // {
   inherit (source) version src pname;
 
   # This for one sets meta.position to where the project is defined

--- a/pythonPackages/buildPythonPackage.nix
+++ b/pythonPackages/buildPythonPackage.nix
@@ -7,15 +7,15 @@
 
 # Arguments provided to flox.buildPythonPackage()
 { project # the name of the project, required
-, nativeBuildInputs ? [ ], ... }@args:
+, channel ? meta.importingChannel, nativeBuildInputs ? [ ], ... }@args:
 
-let source = meta.getBuilderSource project args;
+let source = meta.getChannelSource channel project args;
 in builtins.trace (''flox.buildPythonPackage(project="'' + project + ''", ''
   + ''python.version="'' + python.version + ''", '' + "with "
   + builtins.toString (builtins.length (builtins.attrNames pythonPackages))
   + " pythonPackages)")
 # Actually create the derivation.
-pythonPackages.buildPythonPackage (args // {
+pythonPackages.buildPythonPackage (removeAttrs args [ "channel" ] // {
   inherit (source) version src pname;
 
   # This for one sets meta.position to where the project is defined

--- a/tests/builder-override/channels/builder/default.nix
+++ b/tests/builder-override/channels/builder/default.nix
@@ -1,0 +1,1 @@
+import <flox/channel> { topdir = ./.; }

--- a/tests/builder-override/channels/builder/pkgs/mkDerivation.nix
+++ b/tests/builder-override/channels/builder/pkgs/mkDerivation.nix
@@ -1,0 +1,9 @@
+{ flox, meta }:
+args:
+flox.mkDerivation ({
+  channel = meta.importingChannel;
+} // args // {
+  postInstall = args.postInstall or "" + ''
+    ln -s .flox.json $out/info.json
+  '';
+})

--- a/tests/builder-override/channels/root-meta/srcs/vitetris.json
+++ b/tests/builder-override/channels/root-meta/srcs/vitetris.json
@@ -1,0 +1,17 @@
+{
+  "branches": {
+    "master": "9bbea4f5ab35d6fb8fe70c14daba19e7f35ab44e"
+  },
+  "srcs": {
+    "9bbea4f5ab35d6fb8fe70c14daba19e7f35ab44e": {
+      "url": "https://github.com/vicgeralds/vitetris",
+      "rev": "9bbea4f5ab35d6fb8fe70c14daba19e7f35ab44e",
+      "date": "2020-12-26T12:11:21+01:00",
+      "path": "/nix/store/l69br99gp7652rapravl2mi4c0ml2sjj-vitetris",
+      "sha256": "1ah1c5g7abksif0n8v5rb7r4pn2az20c3mkp4ak13vgs23ddmds5",
+      "fetchSubmodules": false,
+      "version": "1.0",
+      "revision": 0
+    }
+  }
+}

--- a/tests/builder-override/channels/root/default.nix
+++ b/tests/builder-override/channels/root/default.nix
@@ -1,0 +1,1 @@
+import <flox/channel> { topdir = ./.; }

--- a/tests/builder-override/channels/root/pkgs/vitetris/default.nix
+++ b/tests/builder-override/channels/root/pkgs/vitetris/default.nix
@@ -1,0 +1,1 @@
+{ channels }: channels.builder.mkDerivation { project = "vitetris"; }

--- a/tests/builder-override/config.nix
+++ b/tests/builder-override/config.nix
@@ -1,0 +1,22 @@
+{ jq, nixpkgs, repo }: {
+  type = "build";
+  exitCode = 0;
+  nixPath = [
+    {
+      prefix = "nixpkgs";
+      path = nixpkgs;
+    }
+    {
+      prefix = "flox";
+      path = repo;
+    }
+    {
+      prefix = "";
+      path = ./channels;
+    }
+  ];
+  postCommands = [
+    "result/bin/tetris --help"
+    "${jq}/bin/jq -e -n --argjson contents \"$(cat result/info.json)\" '$contents | .rev'"
+  ];
+}

--- a/tests/builder-override/expression.nix
+++ b/tests/builder-override/expression.nix
@@ -1,0 +1,1 @@
+(import <root> { }).vitetris


### PR DESCRIPTION
Builders can be overridden, but care needs to be taken to use the `meta.getBuilderSource` from the new builder definition, in order to use the project sources of the channel that imports this overridden builder, instead of the channel where the builder is defined.

- [x] I have created a test to cover the new behavior.
- [x] I have written and updated relevant documentation, including updating this
      pull request template if necessary. Note that we try to follow the
      [Divio documentation](https://documentation.divio.com/) of documentation.

