### PR TITLE
Introduce flox.importNix

### DIFF
--- a/beamPackages/buildErlangMk.nix
+++ b/beamPackages/buildErlangMk.nix
@@ -3,7 +3,7 @@
 # from metadata cached by the nixpkgs mechanism.
 
 # Arguments provided to callPackage().
-{ lib, beamPackages, meta, ... }:
+{ lib, beamPackages, buildErlangMk, meta, ... }:
 
 # Arguments provided to flox.mkDerivation()
 { project # the name of the project, required
@@ -11,7 +11,7 @@
 let
   source = meta.getChannelSource channel project args;
   # Actually create the derivation.
-in beamPackages.buildErlangMk (removeAttrs args [ "channel" ] // {
+in buildErlangMk (removeAttrs args [ "channel" ] // {
   # build-erlang-mk.nix re-appends the version to the name,
   # so we need to not inherit name and instead pass what we
   # call "pname" as "name".

--- a/channel/output.nix
+++ b/channel/output.nix
@@ -207,10 +207,12 @@ let
     lib.mapAttrs (pname: value:
       withVerbosity 8 (builtins.trace
         "[channel ${myArgs.name}] [packageSet ${name}] Auto-calling package ${pname}")
-      (lib.callPackageWith (packageScope super pname) value.value { } // {
+      ({
         # Allows getting back to the file that was used with e.g. `nix-instantiate --eval -A foo._floxPath`
+        # Note that we let the callPackage result override this because builders
+        # like flox.importNix are able to provide a more accurate file location
         _floxPath = value.path;
-      }));
+      } // lib.callPackageWith (packageScope super pname) value.value { }));
 
   packageSetOutputs = setName: spec:
     let

--- a/channel/tests/mapDirectory/channels/test/pkgs/javaPackages.nix
+++ b/channel/tests/mapDirectory/channels/test/pkgs/javaPackages.nix
@@ -1,1 +1,1 @@
-{ meta, callPackage }: meta.mapDirectory callPackage ../javaPackages
+{ meta }: meta.mapDirectory ../javaPackages

--- a/channel/tests/package-python-dep-override/channels/test/pythonPackages/black/default.nix
+++ b/channel/tests/package-python-dep-override/channels/test/pythonPackages/black/default.nix
@@ -1,4 +1,5 @@
 { black, toml, pythonPackages }: {
+  name = "overriddenblack";
   result = {
     blackName = black.name;
     tomlResult = toml.result;

--- a/channel/tests/package-python-dep-override/stdout
+++ b/channel/tests/package-python-dep-override/stdout
@@ -1,1 +1,1 @@
-{ black = { blackName = "python3.8-black-19.10b0"; blackName2 = "python3.8-black-19.10b0"; tomlResult = "my-toml"; tomlResult2 = "my-toml"; }; }
+{ black = { blackName = "python3.8-black-19.10b0"; blackName2 = "overriddenblack"; tomlResult = "my-toml"; tomlResult2 = "my-toml"; }; }

--- a/channel/tests/package-python-override/channels/test/pythonPackages/toml/default.nix
+++ b/channel/tests/package-python-override/channels/test/pythonPackages/toml/default.nix
@@ -1,1 +1,1 @@
-{ pythonPackages }: { result = pythonPackages.toml.name; }
+{ toml }: { result = toml.name; }

--- a/docs/builders.md
+++ b/docs/builders.md
@@ -295,3 +295,22 @@ Erlang packages declared with this function in `./beamPackages` are version-agno
 Erlang applications declared with this function in `./pkgs` can choose the version:
 - `flox.beamPackages.buildErlangMk`: Uses the default Erlang version of nixpkgs (currently Erlang 22.3)
 - `flox.beam.packages.erlangRXX.mkDerivation`: Uses Erlang version XX, e.g. `erlangR18` for Erlang 18.x or `erlangR23` for Erlang 23.x. Only versions available in nixpkgs are supported, and this will change over time.
+
+## `flox.importNix`
+
+[(source)](../pkgs/importNix.nix)
+
+A convenience function for deferring a package definition to a Nix file in the project repository itself.
+
+**For files:** (any)
+
+#### Inputs
+- `path` (string, mandatory): The relative Nix file path within `<project>` to use for defining this package. If this is a directory, its `default.nix` file will be used. This file is then treated as if it stood in for the `importNix` definition, getting access to the [same call scope](./channel-construction.md#call-scope).
+- `project` (string, mandatory): The name of the GitHub repository in your organization to use for getting the Nix file source of this package. This is passed as the [`<project>` argument](./channel-construction.md#argument-project-string) to `meta.getChannelSource`.
+- `channel` (string, optional, default [`meta.importingChannel`](./channel-construction.md#importingchannel)): The name of the channel, aka GitHub user/organization to get the `<project>` from. Defaults to the channel that uses/imports this builder. This is passed as the [`<channel>` argument](./channel-construction.md#argument-channel-string) to `meta.getChannelSource`.
+- All other arguments are passed as the [`<overrides>` argument](./channel-construction.md#argument-overrides-string) to `meta.getChannelSource`. See [its documentation](channel-construction.md#getchannelsource-channel-project-overrides) for how the source can be influenced with this.
+
+#### Returns
+The result of the Nix file specified in the arguments, as if that file were in this ones place.
+
+Assuming it uses a flox builder, it also contains the [common return attributes](#common-return-attributes).

--- a/pkgs/importNix.nix
+++ b/pkgs/importNix.nix
@@ -1,0 +1,15 @@
+{ meta, callPackage }:
+
+{ channel ? meta.importingChannel, project, path, ... }@args:
+let
+  source = meta.getChannelSource channel project args;
+  fullPath = source.src + "/${path}";
+  fullPathChecked = if builtins.pathExists fullPath then
+    fullPath
+  else
+    throw
+    "File ${path} doesn't exist in source for project ${project} in channel ${meta.importingChannel}";
+in callPackage fullPathChecked { } // {
+  # flox edit should edit the path specified here
+  _floxPath = fullPath;
+}

--- a/pythonPackages/buildPythonApplication.nix
+++ b/pythonPackages/buildPythonApplication.nix
@@ -3,7 +3,7 @@
 # metadata cached by the nixpkgs mechanism.
 
 # Arguments provided to callPackage().
-{ python, pythonPackages, lib, meta }:
+{ python, pythonPackages, buildPythonApplication, lib, meta }:
 
 # Arguments provided to flox.mkDerivation()
 { project # the name of the project, required
@@ -15,7 +15,7 @@ in builtins.trace (''flox.buildPythonApplication(project="'' + project + ''", ''
   + " pythonPackages)")
 
 # Actually create the derivation.
-pythonPackages.buildPythonApplication (removeAttrs args [ "channel" ] // {
+buildPythonApplication (removeAttrs args [ "channel" ] // {
   inherit (source) version src pname;
 
   # This for one sets meta.position to where the project is defined

--- a/pythonPackages/buildPythonPackage.nix
+++ b/pythonPackages/buildPythonPackage.nix
@@ -3,7 +3,7 @@
 # metadata cached by the nixpkgs mechanism.
 
 # Arguments provided to callPackage().
-{ python, pythonPackages, lib, meta }:
+{ python, pythonPackages, buildPythonPackage, lib, meta }:
 
 # Arguments provided to flox.buildPythonPackage()
 { project # the name of the project, required
@@ -15,7 +15,7 @@ in builtins.trace (''flox.buildPythonPackage(project="'' + project + ''", ''
   + builtins.toString (builtins.length (builtins.attrNames pythonPackages))
   + " pythonPackages)")
 # Actually create the derivation.
-pythonPackages.buildPythonPackage (removeAttrs args [ "channel" ] // {
+buildPythonPackage (removeAttrs args [ "channel" ] // {
   inherit (source) version src pname;
 
   # This for one sets meta.position to where the project is defined

--- a/tests/importNix/channels/root/default.nix
+++ b/tests/importNix/channels/root/default.nix
@@ -1,0 +1,1 @@
+import <flox/channel> { topdir = ./.; }

--- a/tests/importNix/channels/root/pkgs/testPackage/default.nix
+++ b/tests/importNix/channels/root/pkgs/testPackage/default.nix
@@ -1,0 +1,6 @@
+{ flox }:
+flox.importNix {
+  project = "testPackage";
+  src = ./src;
+  path = "flox.nix";
+}

--- a/tests/importNix/channels/root/pkgs/testPackage/default.nix
+++ b/tests/importNix/channels/root/pkgs/testPackage/default.nix
@@ -1,5 +1,5 @@
-{ flox }:
-flox.importNix {
+{ meta }:
+meta.importNix {
   project = "testPackage";
   src = ./src;
   path = "flox.nix";

--- a/tests/importNix/channels/root/pkgs/testPackage/src/flox.nix
+++ b/tests/importNix/channels/root/pkgs/testPackage/src/flox.nix
@@ -1,0 +1,6 @@
+{ flox, hello }:
+flox.mkDerivation {
+  project = "testPackage";
+  src = hello.src;
+  version = "1.0";
+}

--- a/tests/importNix/config.nix
+++ b/tests/importNix/config.nix
@@ -1,0 +1,22 @@
+{ jq, nixpkgs, repo }: {
+  type = "build";
+  exitCode = 0;
+  nixPath = [
+    {
+      prefix = "nixpkgs";
+      path = nixpkgs;
+    }
+    {
+      prefix = "flox";
+      path = repo;
+    }
+    {
+      prefix = "";
+      path = ./channels;
+    }
+  ];
+  postCommands = [
+    "result/bin/hello"
+    "${jq}/bin/jq -e -n --argjson contents \"$(cat result/.flox.json)\" '$contents | .pname'"
+  ];
+}

--- a/tests/importNix/expression.nix
+++ b/tests/importNix/expression.nix
@@ -1,0 +1,1 @@
+(import <root> { }).testPackage

--- a/tests/importNix_floxPath/channels/root/default.nix
+++ b/tests/importNix_floxPath/channels/root/default.nix
@@ -1,0 +1,1 @@
+import <flox/channel> { topdir = ./.; }

--- a/tests/importNix_floxPath/channels/root/pkgs/testPackage/default.nix
+++ b/tests/importNix_floxPath/channels/root/pkgs/testPackage/default.nix
@@ -1,0 +1,6 @@
+{ flox }:
+flox.importNix {
+  project = "testPackage";
+  src = ./src;
+  path = "flox.nix";
+}

--- a/tests/importNix_floxPath/channels/root/pkgs/testPackage/default.nix
+++ b/tests/importNix_floxPath/channels/root/pkgs/testPackage/default.nix
@@ -1,5 +1,5 @@
-{ flox }:
-flox.importNix {
+{ meta }:
+meta.importNix {
   project = "testPackage";
   src = ./src;
   path = "flox.nix";

--- a/tests/importNix_floxPath/channels/root/pkgs/testPackage/src/flox.nix
+++ b/tests/importNix_floxPath/channels/root/pkgs/testPackage/src/flox.nix
@@ -1,0 +1,6 @@
+{ flox, hello }:
+flox.mkDerivation {
+  project = "testPackage";
+  src = hello.src;
+  version = "1.0";
+}

--- a/tests/importNix_floxPath/config.nix
+++ b/tests/importNix_floxPath/config.nix
@@ -1,0 +1,18 @@
+{ jq, nixpkgs, repo }: {
+  type = "eval";
+  exitCode = 0;
+  nixPath = [
+    {
+      prefix = "nixpkgs";
+      path = nixpkgs;
+    }
+    {
+      prefix = "flox";
+      path = repo;
+    }
+    {
+      prefix = "";
+      path = ./channels;
+    }
+  ];
+}

--- a/tests/importNix_floxPath/expression.nix
+++ b/tests/importNix_floxPath/expression.nix
@@ -1,0 +1,1 @@
+(import <root> { }).testPackage._floxPath

--- a/tests/importNix_floxPath/stdout
+++ b/tests/importNix_floxPath/stdout
@@ -1,0 +1,1 @@
+.*/src/flox.nix


### PR DESCRIPTION
Convenience function for deferring the Nix definition to a project
repository

- [x] I have created a test to cover the new behavior.
- [x] I have written and updated relevant documentation, including updating this
      pull request template if necessary. Note that we try to follow the
      [Divio documentation](https://documentation.divio.com/) of documentation.

