### PR TITLE
Better auto-call scoping and introduce `meta.importNix`

### DIFF
--- a/beamPackages/buildErlangMk.nix
+++ b/beamPackages/buildErlangMk.nix
@@ -3,7 +3,7 @@
 # from metadata cached by the nixpkgs mechanism.
 
 # Arguments provided to callPackage().
-{ lib, beamPackages, meta, ... }:
+{ lib, beamPackages, buildErlangMk, meta, ... }:
 
 # Arguments provided to flox.mkDerivation()
 { project # the name of the project, required
@@ -11,7 +11,7 @@
 let
   source = meta.getChannelSource channel project args;
   # Actually create the derivation.
-in beamPackages.buildErlangMk (removeAttrs args [ "channel" ] // {
+in buildErlangMk (removeAttrs args [ "channel" ] // {
   # build-erlang-mk.nix re-appends the version to the name,
   # so we need to not inherit name and instead pass what we
   # call "pname" as "name".

--- a/channel/output.nix
+++ b/channel/output.nix
@@ -67,9 +67,9 @@ let
       lDrv = lib.isDerivation l;
       rDrv = lib.isDerivation r;
       prettyPath = lib.concatStringsSep "." path;
-      error = "Trying to override ${
-          lib.optionalString (!lDrv) "non-"
-        }derivation in nixpkgs"
+      warning = "Overriding ${lib.optionalString (!lDrv) "non-"}derivation ${
+          lib.concatStringsSep "." path
+        } in nixpkgs"
         + " with a ${lib.optionalString (!rDrv) "non-"}derivation in channel";
     in if lDrv == rDrv then
     # If both sides are derivations, override completely
@@ -89,7 +89,7 @@ let
             builtins.typeOf l
           } and right is ${builtins.typeOf r}") true
     else
-      throw error);
+      lib.warn warning true);
 
   # Turns a directory into an attribute set.
   # Files with a .nix suffix get turned into an attribute name without the
@@ -258,9 +258,6 @@ let
               # Only pass the super version if it doesn't override an unoverridable attribute!
               // lib.optionalAttrs (!unoverridable ? ${pname}) {
                 ${pname} = super.${pname};
-                ${spec.callScopeAttr} = packageSetScope // {
-                  ${pname} = super.${pname};
-                };
               };
             inherit funs;
           };

--- a/channel/output.nix
+++ b/channel/output.nix
@@ -280,7 +280,11 @@ let
   createSet = spec: super:
     lib.mapAttrs (pname: value:
       let
-        localMeta = meta // { inherit (spec) channels; };
+        localMeta = meta // {
+          inherit (spec) channels;
+
+          inherit scope;
+        };
 
         # TODO: Probably more efficient to directly inspect function arguments and fill these entries out.
         # A callPackage abstraction that allows specifying multiple attribute sets might be nice

--- a/channel/output.nix
+++ b/channel/output.nix
@@ -285,8 +285,10 @@ let
         # TODO: Probably more efficient to directly inspect function arguments and fill these entries out.
         # A callPackage abstraction that allows specifying multiple attribute sets might be nice
         createScope = isOwn:
-          baseScope // spec.extraScope
-          // lib.optionalAttrs isOwn { ${pname} = super.${pname}; } // {
+          baseScope // spec.extraScope // lib.optionalAttrs isOwn {
+            ${pname} = super.${pname} or (throw
+              "${pname} is accessed in ${value.path}, but is not defined because nixpkgs has no ${pname} attribute");
+          } // {
             # These attributes are reserved
             meta = localMeta;
             inherit (localMeta) channels;

--- a/channel/output.nix
+++ b/channel/output.nix
@@ -286,6 +286,21 @@ let
             { call ? path: callPackage path { } }:
             lib.mapAttrs (name: value: call value.path)
             (dirToAttrs "mapDirectory ${baseNameOf dir}" dir);
+
+          importNix =
+            { channel ? meta.importingChannel, project, path, ... }@args:
+            let
+              source = meta.getChannelSource channel project args;
+              fullPath = source.src + "/${path}";
+              fullPathChecked = if builtins.pathExists fullPath then
+                fullPath
+              else
+                throw
+                "`meta.importNix` in ${value.path}: File ${path} doesn't exist in source for project ${project} in channel ${meta.importingChannel}";
+            in {
+              # flox edit should edit the path specified here
+              _floxPath = fullPath;
+            } // ownCallPackage fullPathChecked { };
         };
 
         # TODO: Probably more efficient to directly inspect function arguments and fill these entries out.

--- a/channel/tests/importNix/channels/root/default.nix
+++ b/channel/tests/importNix/channels/root/default.nix
@@ -1,0 +1,1 @@
+import <flox/channel> { topdir = ./.; }

--- a/channel/tests/importNix/channels/root/pkgs/testPackage/default.nix
+++ b/channel/tests/importNix/channels/root/pkgs/testPackage/default.nix
@@ -1,0 +1,6 @@
+{ meta }:
+meta.importNix {
+  project = "testPackage";
+  src = ./src;
+  path = "flox.nix";
+}

--- a/channel/tests/importNix/channels/root/pkgs/testPackage/src/flox.nix
+++ b/channel/tests/importNix/channels/root/pkgs/testPackage/src/flox.nix
@@ -1,0 +1,6 @@
+{ flox, hello }:
+flox.mkDerivation {
+  project = "testPackage";
+  src = hello.src;
+  version = "1.0";
+}

--- a/channel/tests/importNix/config.nix
+++ b/channel/tests/importNix/config.nix
@@ -1,0 +1,22 @@
+{ jq, nixpkgs, repo }: {
+  type = "build";
+  exitCode = 0;
+  nixPath = [
+    {
+      prefix = "nixpkgs";
+      path = nixpkgs;
+    }
+    {
+      prefix = "flox";
+      path = repo;
+    }
+    {
+      prefix = "";
+      path = ./channels;
+    }
+  ];
+  postCommands = [
+    "result/bin/hello"
+    "${jq}/bin/jq -e -n --argjson contents \"$(cat result/.flox.json)\" '$contents | .pname'"
+  ];
+}

--- a/channel/tests/importNix/expression.nix
+++ b/channel/tests/importNix/expression.nix
@@ -1,0 +1,1 @@
+(import <root> { }).testPackage

--- a/channel/tests/importNix_floxPath/channels/root/default.nix
+++ b/channel/tests/importNix_floxPath/channels/root/default.nix
@@ -1,0 +1,1 @@
+import <flox/channel> { topdir = ./.; }

--- a/channel/tests/importNix_floxPath/channels/root/pkgs/testPackage/default.nix
+++ b/channel/tests/importNix_floxPath/channels/root/pkgs/testPackage/default.nix
@@ -1,0 +1,6 @@
+{ meta }:
+meta.importNix {
+  project = "testPackage";
+  src = ./src;
+  path = "flox.nix";
+}

--- a/channel/tests/importNix_floxPath/channels/root/pkgs/testPackage/src/flox.nix
+++ b/channel/tests/importNix_floxPath/channels/root/pkgs/testPackage/src/flox.nix
@@ -1,0 +1,6 @@
+{ flox, hello }:
+flox.mkDerivation {
+  project = "testPackage";
+  src = hello.src;
+  version = "1.0";
+}

--- a/channel/tests/importNix_floxPath/config.nix
+++ b/channel/tests/importNix_floxPath/config.nix
@@ -1,0 +1,18 @@
+{ jq, nixpkgs, repo }: {
+  type = "eval";
+  exitCode = 0;
+  nixPath = [
+    {
+      prefix = "nixpkgs";
+      path = nixpkgs;
+    }
+    {
+      prefix = "flox";
+      path = repo;
+    }
+    {
+      prefix = "";
+      path = ./channels;
+    }
+  ];
+}

--- a/channel/tests/importNix_floxPath/expression.nix
+++ b/channel/tests/importNix_floxPath/expression.nix
@@ -1,0 +1,1 @@
+(import <root> { }).testPackage._floxPath

--- a/channel/tests/importNix_floxPath/stdout
+++ b/channel/tests/importNix_floxPath/stdout
@@ -1,0 +1,1 @@
+.*/src/flox.nix

--- a/channel/tests/mapDirectory/channels/test/pkgs/javaPackages.nix
+++ b/channel/tests/mapDirectory/channels/test/pkgs/javaPackages.nix
@@ -1,1 +1,1 @@
-{ meta, callPackage }: meta.mapDirectory callPackage ../javaPackages
+{ meta }: meta.mapDirectory ../javaPackages { }

--- a/channel/tests/package-python-dep-override/channels/test/pythonPackages/black/default.nix
+++ b/channel/tests/package-python-dep-override/channels/test/pythonPackages/black/default.nix
@@ -1,4 +1,5 @@
 { black, toml, pythonPackages }: {
+  name = "overriddenblack";
   result = {
     blackName = black.name;
     tomlResult = toml.result;

--- a/channel/tests/package-python-dep-override/stdout
+++ b/channel/tests/package-python-dep-override/stdout
@@ -1,1 +1,1 @@
-{ black = { blackName = "python3.8-black-19.10b0"; blackName2 = "python3.8-black-19.10b0"; tomlResult = "my-toml"; tomlResult2 = "my-toml"; }; }
+{ black = { blackName = "python3.8-black-19.10b0"; blackName2 = "overriddenblack"; tomlResult = "my-toml"; tomlResult2 = "my-toml"; }; }

--- a/channel/tests/package-python-override/channels/test/pythonPackages/toml/default.nix
+++ b/channel/tests/package-python-override/channels/test/pythonPackages/toml/default.nix
@@ -1,1 +1,1 @@
-{ pythonPackages }: { result = pythonPackages.toml.name; }
+{ toml }: { result = toml.name; }

--- a/docs/channel-construction.md
+++ b/docs/channel-construction.md
@@ -150,25 +150,25 @@ The argument to pass to `<fun>` if `debugVerbosity` is above or equal to the pas
 - If `debugVerbosity` is greater or equal than `<verbosity>`, returns `<arg>` applied to `<fun>`
 - Otherwise returns `<arg>`
 
-#### `mapDirectory <callPackage> <directory>`
+#### `mapDirectory <directory> { call? }`
 
-Imports all Nix files and subdirectories of `<directory>`, importing them and turning them into Nix values by calling `<callPackage>` on them. This allows declaring local ad-hoc package sets. For example, with `pkgs/myPackages.nix` containing
+Imports all Nix files and subdirectories of `<directory>`, importing them and turning them into Nix values by auto-calling them with [`scope`](#scope). This allows declaring local ad-hoc package sets. For example, with `pkgs/myPackages.nix` containing
 
 ```nix
-{ meta, callPackage }: meta.mapDirectory callPackage ../myPackages`
+{ meta }: meta.mapDirectory ../myPackages {}
 ```
 
 any files in `myPackages` get turned into an attribute nested under the `myPackages` output attribute.
 
 Note that unlike [built-in package](./package-sets.md) sets like `pythonPackages`, `perlPackages`, there's no special handling of scope and versions with `mapDirectory`. It's just a simple collection of nested attributes.
 
-##### Argument `<callPackage>` (function)
-
-The `callPackage` function to use for autocalling the imported files.
-
 ##### Argument `<directory>` (path)
 
 The directory to import paths from.
+
+##### Argument `<call>` (function)
+
+The function to call on each path to transform it to a value. Defaults to `path: callPackage path {}`.
 
 ##### Returns
 

--- a/docs/channel-construction.md
+++ b/docs/channel-construction.md
@@ -173,3 +173,18 @@ The function to call on each path to transform it to a value. Defaults to `path:
 ##### Returns
 
 An attribute set containing attributes for every `<directory>/<name>.nix` file and every `<directory>/<name>` subdirectory, the files are turned to values with `<callPackage>`.
+
+## `importNix { path, project, channel?, ... }` (experimental)
+
+An experimental convenience function for deferring a package definition to a Nix file in the project repository itself.
+
+##### Inputs
+- `path` (string, mandatory): The relative Nix file path within `<project>` to use for defining this package. If this is a directory, its `default.nix` file will be used. This file is then treated as if it stood in for the `importNix` definition, getting access to the [same call scope](./channel-construction.md#call-scope).
+- `project` (string, mandatory): The name of the GitHub repository in your organization to use for getting the Nix file source of this package. This is passed as the [`<project>` argument](./channel-construction.md#argument-project-string) to `meta.getChannelSource`.
+- `channel` (string, optional, default [`meta.importingChannel`](./channel-construction.md#importingchannel)): The name of the channel, aka GitHub user/organization to get the `<project>` from. Defaults to the channel that uses/imports this builder. This is passed as the [`<channel>` argument](./channel-construction.md#argument-channel-string) to `meta.getChannelSource`.
+- All other arguments are passed as the [`<overrides>` argument](./channel-construction.md#argument-overrides-string) to `meta.getChannelSource`. See [its documentation](channel-construction.md#getchannelsource-channel-project-overrides) for how the source can be influenced with this.
+
+##### Returns
+The result of the Nix file specified in the arguments, as if that file were in this ones place.
+
+Assuming it uses a flox builder, it also contains the [common return attributes](#common-return-attributes).

--- a/docs/channel-construction.md
+++ b/docs/channel-construction.md
@@ -122,6 +122,10 @@ The channel from which this channel is accessed. In case this channel is accesse
 
 Like [`getChannelSource`](#getChannelSource-channel-project-overrides), but with [`ownChannel`](#ownChannel) passed as the `<channel>` argument.
 
+#### `scope`
+
+The scope with which the current package has been auto-called, useful if the scope needs to be extended.
+
 #### `withVerbosity <verbosity> <fun> <arg>`
 
 Applies `<fun>` to `<arg>` only if the configured `debugVerbosity` is equal or higher than `<verbosity>`. With `<fun>` doing tracing, this allows controlling the verbosity level of the traced value. Example: `withVerbosity 5 (builtins.trace "Some message") 1`

--- a/docs/channel-construction.md
+++ b/docs/channel-construction.md
@@ -69,7 +69,6 @@ In addition, for all package sets in [above table](#subdirectories) that have a 
 - `<attr>`: A version-agnostic package set consisting of:
   - The packages in nixpkgs
   - This channels packages
-  - `<name>`: The package in nixpkgs of the same name as the one defined. This allows package overriding without getting infinite recursion
 - All attributes of the above set
 - `channels`: An attribute set containing the outputs of all other available channels:
   - `channels.<channel>.<output>`: Output attribute `<output>` of channel `<channel>`

--- a/pythonPackages/buildPythonApplication.nix
+++ b/pythonPackages/buildPythonApplication.nix
@@ -3,7 +3,7 @@
 # metadata cached by the nixpkgs mechanism.
 
 # Arguments provided to callPackage().
-{ python, pythonPackages, lib, meta }:
+{ python, pythonPackages, buildPythonApplication, lib, meta }:
 
 # Arguments provided to flox.mkDerivation()
 { project # the name of the project, required
@@ -15,7 +15,7 @@ in builtins.trace (''flox.buildPythonApplication(project="'' + project + ''", ''
   + " pythonPackages)")
 
 # Actually create the derivation.
-pythonPackages.buildPythonApplication (removeAttrs args [ "channel" ] // {
+buildPythonApplication (removeAttrs args [ "channel" ] // {
   inherit (source) version src pname;
 
   # This for one sets meta.position to where the project is defined

--- a/pythonPackages/buildPythonPackage.nix
+++ b/pythonPackages/buildPythonPackage.nix
@@ -3,7 +3,7 @@
 # metadata cached by the nixpkgs mechanism.
 
 # Arguments provided to callPackage().
-{ python, pythonPackages, lib, meta }:
+{ python, pythonPackages, buildPythonPackage, lib, meta }:
 
 # Arguments provided to flox.buildPythonPackage()
 { project # the name of the project, required
@@ -15,7 +15,7 @@ in builtins.trace (''flox.buildPythonPackage(project="'' + project + ''", ''
   + builtins.toString (builtins.length (builtins.attrNames pythonPackages))
   + " pythonPackages)")
 # Actually create the derivation.
-pythonPackages.buildPythonPackage (removeAttrs args [ "channel" ] // {
+buildPythonPackage (removeAttrs args [ "channel" ] // {
   inherit (source) version src pname;
 
   # This for one sets meta.position to where the project is defined


### PR DESCRIPTION
Contains a number of changes:
- [backwards incompatibility] Removes access to the super version of a package via `<packageset>.<pname>`. This just complicated the code for no good reason, as the super version is also accessible via just `<pname>`. Doing this allows the next commit. This is a backwards incompatibility, but it's a reasonable one. This only requires a change if e.g. in `pythonPackages/foo/default.nix` something like
  ```nix
  { pythonPackages }: pythonPackages.foo.overridePythonAttrs { ... }
  ```
  was done. This has to be changed to just
  ```nix
  { foo }: foo.overridePythonAttrs { ... }
  ```
- Refactors the auto-call scoping code to remove some duplication, useful for the changes below
- Make accessing the super version of the package throw a better error if it doesn't exist. E.g. this makes
  ```nix
  { florp }: florp.override { ... }
  ```
  throw the error
  ```
  error: florp is accessed in /some/path/pkgs/florp, but is not defined because nixpkgs has no florp attribute
  ```
- Introduce `meta.scope`. This allows access to the auto-call scope directly. Can be used to create a `callPackage` that extends the scope, e.g. `lib.callPackageWith (meta.scope // { <extra stuff> })`
- [backwards incompatibility] Change `mapDirectory` arguments. Changes `mapDirectory <callPackage> <dir>` to `mapDirectory <dir> { call? }`, now invokable with just `mapDirectory ./some/dir {}`. This is done to not have to pass in `callPackage` explicitly and for future extensibility.
- Introduce experimental `meta.importNix`. This is a utility to defer the Nix definition of a package to a source repository. E.g. can be used in `pkgs/foo.nix` with
  ```nix
  { meta }:
  meta.importNix {
    project = "foo";
    path = "flox.nix";
  }
  ```
  which will then treat the `flox.nix` file in the `foo` repository as if it were in this files place.

- [x] I have created a test to cover the new behavior.
- [x] I have written and updated relevant documentation, including updating this
      pull request template if necessary. Note that we try to follow the
      [Divio documentation](https://documentation.divio.com/) of documentation.

