### PR TITLE
Fix capacitor-default.exp

### DIFF
--- a/test/capacitor-default.exp
+++ b/test/capacitor-default.exp
@@ -1,7 +1,7 @@
 #!/usr/bin/expect
 set err 1
 set timeout -1
-spawn flox develop --refresh --override-input capacitor github:flox/capacitor?rev=$env(GITHUB_SHA)
+spawn flox develop --refresh --override-input capacitor github:flox/decapacitor?rev=$env(GITHUB_SHA)
 expect {
     "λ" {
       set err 0


### PR DESCRIPTION
The test overrides the capacitor version to a commit given by the test runner.
As development branches (read "commits") are only available on *de*capacitor the injected capacitor commit needs to come from the decapacitor repository