### PR TITLE
nix-editor and devshell follow nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,7 +43,7 @@
     },
     "capacitor_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_3",
         "root": [
           "nixpkgs"
         ]
@@ -66,7 +66,9 @@
     "devshell": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1660811669,
@@ -207,14 +209,16 @@
     },
     "naersk": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1655042882,
-        "narHash": "sha256-9BX8Fuez5YJlN7cdPO63InoyBy7dm3VlJkkmTt6fS1A=",
+        "lastModified": 1659610603,
+        "narHash": "sha256-LYgASYSPYo7O71WfeUOaEUzYfzuXm8c8eavJcel+pfI=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "cddffb5aa211f50c4b8750adbec0bbbdfb26bb9f",
+        "rev": "c6a45e4277fa58abd524681466d3450f896dc094",
         "type": "github"
       },
       "original": {
@@ -227,8 +231,12 @@
       "inputs": {
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils_3",
-        "naersk": "naersk",
-        "nixpkgs": "nixpkgs_4"
+        "naersk": [
+          "naersk"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1658124629,
@@ -333,52 +341,6 @@
       }
     },
     "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1643381941,
-        "narHash": "sha256-pHTwvnN4tTsEKkWlXQ8JMY423epos8wUOhthpwJjtpc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "5efc8ca954272c4376ac929f4c5ffefcc20551d5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1658093278,
-        "narHash": "sha256-uftJGDkMn7RUZVDA3IDZVYiNKgzk1redcejkkcncwv8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "78e748fa68079b77ac055c80ef21342dd7e2ae2b",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1658015103,
-        "narHash": "sha256-mO+23f3SO+fBzEvbxRe6GkSB5Xp43CT2sV8Rs8MYdz8=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "8f485713f5e6b6883a9b6959afa98688360a3ecb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_5": {
       "inputs": {
         "capacitor": "capacitor_2",
         "flox-extras": "flox-extras",
@@ -406,7 +368,7 @@
         "url": "ssh://git@github.com/flox/nixpkgs-flox"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1658826464,
         "narHash": "sha256-94ZTF0uIX/iZdiD4RJ5f933ak/OM4XLl7hF+gCa4Iuk=",
@@ -425,11 +387,11 @@
     "pypi-deps-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1660811860,
-        "narHash": "sha256-ENcR8bScxsPCAg37xJoILDRnk+rl3iTSaH5IeeCzVtk=",
+        "lastModified": 1660902259,
+        "narHash": "sha256-cwUn5zmUXtOR1FyUjbzV56gC+xupSvypxosyz0w5o8k=",
         "owner": "DavHau",
         "repo": "pypi-deps-db",
-        "rev": "d14f7f768f62625784466698735f5a98ed544efa",
+        "rev": "66490c419d52ed149e8b65ed8505eeca755f33ff",
         "type": "github"
       },
       "original": {
@@ -445,8 +407,9 @@
         "devshell": "devshell",
         "flox": "flox",
         "mach-nix": "mach-nix",
+        "naersk": "naersk",
         "nix-editor": "nix-editor",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_2",
         "pypi-deps-db": "pypi-deps-db"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -11,8 +11,15 @@ rec {
   inputs.flox.flake = false;
 
   inputs.nix-editor.url = "github:vlinkz/nix-editor";
+  inputs.nix-editor.inputs.nixpkgs.follows = "nixpkgs";
+  # nix has a bug where it can't add a follows two inputs deep, so add this hack to make naersk
+  # follow nixpkgs
+  inputs.naersk.url = "github:nix-community/naersk";
+  inputs.naersk.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.nix-editor.inputs.naersk.follows = "naersk";
 
   inputs.devshell.url = "github:numtide/devshell";
+  inputs.devshell.inputs.nixpkgs.follows = "nixpkgs";
   inputs.mach-nix.url = "github:DavHau/mach-nix";
   inputs.mach-nix.inputs.nixpkgs.follows = "nixpkgs";
   inputs.mach-nix.inputs.pypi-deps-db.follows = "pypi-deps-db";


### PR DESCRIPTION
This eliminates two copies of nixpkgs