### PR TITLE
Add partial generated catalog

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,17 +66,18 @@
     "catalog": {
       "flake": false,
       "locked": {
-        "lastModified": 1661266233,
-        "narHash": "sha256-jqxONgdOWltditqRTE/3rUuu573xAezp7bKcwotfOwI=",
-        "owner": "samrose",
-        "repo": "floxpkgs-publish",
-        "rev": "1f1baeb963d00770bd61771885eb18365d6c5d2e",
-        "type": "github"
+        "lastModified": 1661282972,
+        "narHash": "sha256-ow4SiSeaW+04/x0N+Mjde3dXGmcuLtsqjHliBPGlmho=",
+        "ref": "publish",
+        "rev": "10bbbe2911ed5ccf11e018b9c2cb43d77eb071ca",
+        "revCount": 131,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/floxpkgs"
       },
       "original": {
-        "owner": "samrose",
-        "repo": "floxpkgs-publish",
-        "type": "github"
+        "ref": "publish",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/floxpkgs"
       }
     },
     "devshell": {

--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660063684,
-        "narHash": "sha256-KmjKfJN8QUgF+/9ytUe+HQ6nTZ+tKmAp3Ge86iy8DrM=",
+        "lastModified": 1660756526,
+        "narHash": "sha256-XS2IJ9jGSwB8iVXMMlgp/7K2C230vPe2KeuZNmaJTFM=",
         "owner": "flox",
         "repo": "flox-extras",
-        "rev": "e1da62aea2c3d441800c52400fb59003b9629030",
+        "rev": "b79addf15c7a683a4b253410e27fbdbff152db6d",
         "type": "github"
       },
       "original": {
@@ -356,7 +356,7 @@
     "nixpkgs.catalog.aarch64-darwin": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-kOkcdNmtrA9qC8EunIYFjpuk5KdSL1SsbxB07wuu2uA=",
+        "narHash": "sha256-L90BnbRdlKeMe2xohbr64fEfC4dzvwCHnA+mJWGJ6a4=",
         "type": "tarball",
         "url": "https://catalog.floxsdlc.com/nixpkgs/catalog.aarch64-darwin.tar.gz"
       },
@@ -368,7 +368,7 @@
     "nixpkgs.catalog.x86_64-linux": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-aa3FCuD7iEK3XnLaezHy7WxeooVmQRO2FZ0ruLgNzao=",
+        "narHash": "sha256-ClZWBxvmGFsO6E47G3zbdh0k5BVt3qtjE+56AGIBiTQ=",
         "type": "tarball",
         "url": "https://catalog.floxsdlc.com/nixpkgs/catalog.x86_64-linux.tar.gz"
       },
@@ -392,11 +392,11 @@
         "nixpkgs.catalog.x86_64-linux": "nixpkgs.catalog.x86_64-linux"
       },
       "locked": {
-        "lastModified": 1660747073,
-        "narHash": "sha256-9iVCqAxK6mLAb2ItIWnp+DR9SQe0/841sa5u1fDhrRo=",
+        "lastModified": 1661269799,
+        "narHash": "sha256-9zzPG9Yb9hbuH73s+CVTOlAXJSkDj7gXYDZQjy4NS/c=",
         "ref": "refs/heads/master",
-        "rev": "c63065c65a93aecb66be8546652b635f79e8e880",
-        "revCount": 83,
+        "rev": "28554d1a006181055bdf6ba64bb02dfc87493cbf",
+        "revCount": 84,
         "type": "git",
         "url": "ssh://git@github.com/flox/nixpkgs-flox"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -63,6 +63,22 @@
         "type": "github"
       }
     },
+    "catalog": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661266233,
+        "narHash": "sha256-jqxONgdOWltditqRTE/3rUuu573xAezp7bKcwotfOwI=",
+        "owner": "samrose",
+        "repo": "floxpkgs-publish",
+        "rev": "1f1baeb963d00770bd61771885eb18365d6c5d2e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "samrose",
+        "repo": "floxpkgs-publish",
+        "type": "github"
+      }
+    },
     "devshell": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -163,6 +179,26 @@
       }
     },
     "flox-extras": {
+      "inputs": {
+        "capacitor": [
+          "capacitor"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660756526,
+        "narHash": "sha256-XS2IJ9jGSwB8iVXMMlgp/7K2C230vPe2KeuZNmaJTFM=",
+        "ref": "refs/heads/master",
+        "rev": "b79addf15c7a683a4b253410e27fbdbff152db6d",
+        "revCount": 13,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox-extras"
+      },
+      "original": {
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox-extras"
+      }
+    },
+    "flox-extras_2": {
       "inputs": {
         "capacitor": [
           "nixpkgs",
@@ -343,7 +379,7 @@
     "nixpkgs_2": {
       "inputs": {
         "capacitor": "capacitor_2",
-        "flox-extras": "flox-extras",
+        "flox-extras": "flox-extras_2",
         "nixpkgs": [
           "nixpkgs",
           "nixpkgs-stable"
@@ -387,11 +423,11 @@
     "pypi-deps-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1660902259,
-        "narHash": "sha256-cwUn5zmUXtOR1FyUjbzV56gC+xupSvypxosyz0w5o8k=",
+        "lastModified": 1661244612,
+        "narHash": "sha256-NkIRtkU+xjObO+Np1fra0X1kYK+Q2xzzLic91obRjfQ=",
         "owner": "DavHau",
         "repo": "pypi-deps-db",
-        "rev": "66490c419d52ed149e8b65ed8505eeca755f33ff",
+        "rev": "4bcaf526de8cbcad2c1eb3bc0160363ce370086b",
         "type": "github"
       },
       "original": {
@@ -404,8 +440,10 @@
       "inputs": {
         "builtfilter": "builtfilter",
         "capacitor": "capacitor",
+        "catalog": "catalog",
         "devshell": "devshell",
         "flox": "flox",
+        "flox-extras": "flox-extras",
         "mach-nix": "mach-nix",
         "naersk": "naersk",
         "nix-editor": "nix-editor",

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@ rec {
   inputs.flox-extras.url = "git+ssh://git@github.com/flox/flox-extras";
   inputs.flox-extras.inputs.capacitor.follows = "capacitor";
 
-  inputs.catalog.url = "github:samrose/floxpkgs-publish";
+  inputs.catalog.url = "git+ssh://git@github.com/flox/floxpkgs?ref=publish";
   inputs.catalog.flake = false;
 
   inputs.nixpkgs.url = "git+ssh://git@github.com/flox/nixpkgs-flox";

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,12 @@
 rec {
   inputs.capacitor.url = "git+ssh://git@github.com/flox/capacitor?ref=v0";
   inputs.capacitor.inputs.root.follows = "/";
+  
+  inputs.flox-extras.url = "git+ssh://git@github.com/flox/flox-extras";
+  inputs.flox-extras.inputs.capacitor.follows = "capacitor";
+
+  inputs.catalog.url = "github:samrose/floxpkgs-publish";
+  inputs.catalog.flake = false;
 
   inputs.nixpkgs.url = "git+ssh://git@github.com/flox/nixpkgs-flox";
 

--- a/flox.nix
+++ b/flox.nix
@@ -26,6 +26,6 @@
     ];
   };
 
-  passthru.catalog = (lib.mapAttrs (system: catalogForSystem: {nixpkgs = catalogForSystem;}) inputs.nixpkgs.catalog);
+  passthru.catalog = (lib.mapAttrs (system: catalogForSystem: lib.recurseIntoAttrs {nixpkgs = catalogForSystem;}) inputs.nixpkgs.catalog);
 
 }

--- a/flox.nix
+++ b/flox.nix
@@ -1,4 +1,4 @@
-{inputs, ...}:
+{inputs, lib,...}:
 # Define package set structure
 {
   # Limit the systems to fewer or more than default by ucommenting
@@ -15,10 +15,17 @@
     };
 
     extraPlugins = [
-      (inputs.flox-extras.plugins.catalog {catalogDirectory = inputs.catalog + "/render/x86_64-linux"; system = "x86_64-linux";})
+      (inputs.flox-extras.plugins.catalog { 
+        catalogDirectory = inputs.catalog + "/render/x86_64-linux"; 
+        system = "x86_64-linux";
+        path = ["floxpkgs"];
+      })
       (inputs.capacitor.plugins.allLocalResources {})
       (inputs.capacitor.plugins.templates {})
       (inputs.capacitor.plugins.nixpkgs)
     ];
   };
+
+  passthru.catalog = (lib.mapAttrs (system: catalogForSystem: {nixpkgs = catalogForSystem;}) inputs.nixpkgs.catalog);
+
 }

--- a/flox.nix
+++ b/flox.nix
@@ -15,6 +15,7 @@
     };
 
     extraPlugins = [
+      (inputs.flox-extras.plugins.catalog {catalogDirectory = inputs.catalog + "/render/x86_64-linux"; system = "x86_64-linux";})
       (inputs.capacitor.plugins.allLocalResources {})
       (inputs.capacitor.plugins.templates {})
       (inputs.capacitor.plugins.nixpkgs)


### PR DESCRIPTION
Integrates the partial catalog built by @samrose.

Eventually the catalog should be generated by a catalog flake or hosted in a more canonical place.

**This flake now makes use of `flox/flox-extras`.**
For customers this needs to be necessarily accessible

related: https://github.com/flox/flox/pull/151