### PR TITLE
Add up-to-date Go template

### DIFF
--- a/templates/go/flake.nix
+++ b/templates/go/flake.nix
@@ -1,0 +1,33 @@
+{
+  inputs.capacitor.url = "git+ssh://git@github.com/flox/capacitor?ref=v0";
+  inputs.capacitor.inputs.root.follows = "/";
+  inputs.capacitor.inputs.nixpkgs.follows = "nixpkgs/nixpkgs-stable";
+
+  inputs.nixpkgs.url = "git+ssh://git@github.com/flox/nixpkgs-flox";
+  inputs.nixpkgs.inputs.capacitor.follows = "capacitor";
+
+  inputs.floxpkgs.url = "git+ssh://git@github.com/flox/floxpkgs";
+  inputs.floxpkgs.inputs.capacitor.follows = "capacitor";
+  inputs.floxpkgs.inputs.nixpkgs.follows = "nixpkgs";
+
+  nixConfig.bash-prompt = "[flox]\\e\[38;5;172mλ \\e\[m";
+
+  outputs = args @ {capacitor, ...}:
+    capacitor args (
+      {
+        inputs,
+        self,
+        lib,
+        ...
+      }: {
+        devShells.default =
+          lib.optionalAttrs
+          (builtins.pathExists ./flox.toml)
+          (inputs.floxpkgs.lib.mkFloxShell ./flox.toml {});
+        description = "Go template";
+        config.extraPlugins = [
+          (inputs.capacitor.plugins.allLocalResources {})
+        ];
+      }
+    );
+}

--- a/templates/go/pkgs/default.nix
+++ b/templates/go/pkgs/default.nix
@@ -1,0 +1,16 @@
+{
+  buildGoModule,
+  lib,
+}:
+buildGoModule {
+  pname = "my-package";
+  version = "0.0.0";
+  src = ../.;
+  # vendorSha256 should be set to null if dependencies are vendored. If the dependencies aren't
+  # vendored, vendorSha256 must be set to a hash of the content of all dependencies. This hash can
+  # be found by setting
+  # vendorSha256 = pkgs.lib.fakeSha256;
+  # and then running flox build. The build will fail but output the expected sha, which can then be
+  # added here.
+  vendorSha256 = null;
+}


### PR DESCRIPTION
Depends https://github.com/flox/floxpkgs/pull/28  (in order to keep discussion about where to put default.nix there)

Fixes: https://github.com/flox/floxpkgs/issues/24