### PR TITLE
Configure stabilities for templates

### DIFF
--- a/templates/floxEnv/flake.nix
+++ b/templates/floxEnv/flake.nix
@@ -27,9 +27,17 @@
           (builtins.pathExists ./flox.toml)
           (inputs.floxpkgs.lib.mkFloxShell ./flox.toml {});
 
-        config.extraPlugins = [
-          (inputs.capacitor.plugins.allLocalResources {})
-        ];
+        config = {
+          stabilities = {
+            stable = inputs.nixpkgs.stable;
+            staging = inputs.nixpkgs.staging;
+            unstable = inputs.nixpkgs.unstable;
+            default = inputs.nixpkgs.stable;
+          };
+          extraPlugins = [
+            (inputs.capacitor.plugins.allLocalResources {})
+          ];
+        };
       }
     );
 }

--- a/templates/go/flake.nix
+++ b/templates/go/flake.nix
@@ -27,9 +27,17 @@
           (builtins.pathExists ./flox.toml)
           (inputs.floxpkgs.lib.mkFloxShell ./flox.toml {});
 
-        config.extraPlugins = [
-          (inputs.capacitor.plugins.allLocalResources {})
-        ];
+        config = {
+          stabilities = {
+            stable = inputs.nixpkgs.stable;
+            staging = inputs.nixpkgs.staging;
+            unstable = inputs.nixpkgs.unstable;
+            default = inputs.nixpkgs.stable;
+          };
+          extraPlugins = [
+            (inputs.capacitor.plugins.allLocalResources {})
+          ];
+        };
       }
     );
 }

--- a/templates/python/flake.nix
+++ b/templates/python/flake.nix
@@ -27,9 +27,17 @@
           (builtins.pathExists ./flox.toml)
           (inputs.floxpkgs.lib.mkFloxShell ./flox.toml {});
 
-        config.extraPlugins = [
-          (inputs.capacitor.plugins.allLocalResources {})
-        ];
+        config = {
+          stabilities = {
+            stable = inputs.nixpkgs.stable;
+            staging = inputs.nixpkgs.staging;
+            unstable = inputs.nixpkgs.unstable;
+            default = inputs.nixpkgs.stable;
+          };
+          extraPlugins = [
+            (inputs.capacitor.plugins.allLocalResources {})
+          ];
+        };
       }
     );
 }

--- a/templates/rust/flake.nix
+++ b/templates/rust/flake.nix
@@ -27,9 +27,17 @@
           (builtins.pathExists ./flox.toml)
           (inputs.floxpkgs.lib.mkFloxShell ./flox.toml {});
 
-        config.extraPlugins = [
-          (inputs.capacitor.plugins.allLocalResources {})
-        ];
+        config = {
+          stabilities = {
+            stable = inputs.nixpkgs.stable;
+            staging = inputs.nixpkgs.staging;
+            unstable = inputs.nixpkgs.unstable;
+            default = inputs.nixpkgs.stable;
+          };
+          extraPlugins = [
+            (inputs.capacitor.plugins.allLocalResources {})
+          ];
+        };
       }
     );
 }


### PR DESCRIPTION
Without this change, floxpkgs.evalCatalog.stable.nixpkgs does not exist

I don't fully understand this, and I thought we decided this wasn't necessary. But when I try to `flox develop` with the current floxEnv template, I'm getting:
```
error: attribute 'nixpkgs' missing

       at /nix/store/143fvsgvx0lkiiav0kcv54yrnxfk5mdw-source/lib//flox-env.nix:62:41:

           61|                   then withVersion (tail path) stability.${head path}
           62|                   else withVersion path stability.nixpkgs;
             |                                         ^
           63|                 # translate version into an attrPath if it's provided. Otherwise, fallback to the
```