### PR TITLE
Rename floxpkgs catalog namespace to "flox"

### DIFF
--- a/flox.nix
+++ b/flox.nix
@@ -29,7 +29,7 @@
         (system: (inputs.flox-extras.plugins.catalog {
           catalogDirectory = inputs.catalog + "/render/${system}";
           inherit system;
-          path = ["floxpkgs"];
+          path = ["flox"];
         })) ["x86_64-linux" "aarch64-darwin"]);
   };
 


### PR DESCRIPTION
- Breaks existing flox (through nix) installations' upgrade url
- Requires Docs to use the new name