### PR TITLE
chore: 0.0.4 release cleanups

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
     "catalog": {
       "flake": false,
       "locked": {
-        "lastModified": 1662718220,
-        "narHash": "sha256-q2bBfVIga3M25qsSKXG87SnsXu8OerCKyvdENvYJBTo=",
+        "lastModified": 1663766937,
+        "narHash": "sha256-LHY4rCBl+FpMfPUx/ZlUs0kB0DOW982lMfXMDItLhDU=",
         "owner": "flox",
         "repo": "floxpkgs",
-        "rev": "acbb70bcf34caf518629aa7157df2117181e2201",
+        "rev": "fe286f105c067c62658c4ae1a0375f187971de8d",
         "type": "github"
       },
       "original": {

--- a/flox.nix
+++ b/flox.nix
@@ -16,7 +16,6 @@
       (inputs.capacitor.plugins.allLocalResources {})
       (inputs.flox-extras.plugins.catalog {
         catalogDirectory = inputs.catalog + "/render";
-        path = ["floxpkgs"];
       })
       (inputs.capacitor.plugins.templates {})
     ];

--- a/flox.nix
+++ b/flox.nix
@@ -15,7 +15,7 @@
     extraPlugins = [
       (inputs.capacitor.plugins.allLocalResources {})
       (inputs.flox-extras.plugins.catalog {
-        catalogDirectory = inputs.catalog + "/render";
+        catalogDirectory = inputs.catalog + "/catalog";
       })
       (inputs.capacitor.plugins.templates {})
     ];

--- a/templates/_init/flake.nix
+++ b/templates/_init/flake.nix
@@ -13,7 +13,7 @@
   # Template DO NOT EDIT
   # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   # TODO: injected by the cli, or used via registry?
-  inputs.floxpkgs.url = "github:flox/floxpkgs/tng";
+  inputs.floxpkgs.url = "github:flox/floxpkgs";
   outputs = args @ {floxpkgs, ...}: floxpkgs.capacitor args (import ./flox.nix);
   # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 }

--- a/templates/_init/flox.nix
+++ b/templates/_init/flox.nix
@@ -11,10 +11,10 @@
   # DO NOT EDIT
   config.extraPlugins = [
       (
-        inputs.flox-extras.plugins.catalog {
+        inputs.floxpkgs.flox-extras.plugins.catalog {
           catalogDirectory = self.outPath + "/catalog";
         }
       )
-      (inputs.capacitor.plugins.allLocalResources {})
+      (inputs.floxpkgs.capacitor.plugins.allLocalResources {})
     ];
 }


### PR DESCRIPTION
- fix: point template to the right branch of floxpkgs
- fix: remove namespace from catalog
- fix: point catalog plugin to the right directory
