### PR TITLE
Re-export catalogs

### DIFF
--- a/flox.nix
+++ b/flox.nix
@@ -29,6 +29,10 @@
     ];
   };
 
+  # reexport of catalogs
+  passthru.catalogs = {
+    nixpkgs = { inherit (inputs.nixpkgs) evalCatalog catalog; };
+  };
   # reexport of capacitor
   passthru.capacitor = inputs.capacitor;
   # reexport of flox-extras


### PR DESCRIPTION
This seems to improve usability when trying to use the nixpkgs catalog in isolated cases, an example of this being our example usage of `mkEnv`, where we have to add this passthru https://github.com/flox-examples/floxEnv/blob/31d0ce3e7d2c5f2c67903546940df7ae40ed3159/flake.nix#L9-L11 so that it can be used here https://github.com/flox-examples/floxEnv/blob/31d0ce3e7d2c5f2c67903546940df7ae40ed3159/pkgs/default.nix#L6.

With this change we should be able to get rid of the passthru and write `with inputs.floxpkgs.catalogs.nixpkgs.evalCatalog;`, and without this change _or_ the passthru we would need to change it to `with inputs.floxpkgs.inputs.nixpkgs.${system}.evalCatalog;` (and acquire `system` from somewhere too).

I've spoken with @ysndr about the possibility of de-system-ing inputs of inputs, but it sounds like that would be difficult, and semantically it is weird to "abuse" floxpkgs as a way to import other things from its inputs if it isn't re-exporting them.

Not sure if this is the best format to do this in, maybe we could have `passthru.catalogs` and `passthru.evalCatalogs` separately? I actually don't know enough about them yet to know what the difference is.