### PR TITLE
treewide: use withRev to set revisioned version in templates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,24 @@
 {
   "nodes": {
+    "Curious-Ways": {
+      "inputs": {
+        "floxpkgs": "floxpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1668536439,
+        "narHash": "sha256-rFRfdu3IAvnNBxg4BOMuD41xdWAQiHdbxhbBEawXLLY=",
+        "ref": "main",
+        "rev": "d1ac106dd979c8d098ceec3a5c0967a2f221f01b",
+        "revCount": 215,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/Curious-Ways"
+      },
+      "original": {
+        "ref": "main",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/Curious-Ways"
+      }
+    },
     "builtfilter": {
       "inputs": {
         "capacitor": [
@@ -25,7 +44,11 @@
       "inputs": {
         "capacitor": [
           "flox",
+<<<<<<< HEAD
           "flox-floxpkgs",
+=======
+          "floxpkgs",
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
           "capacitor"
         ]
       },
@@ -44,16 +67,67 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
+=======
+    "builtfilter_3": {
+      "inputs": {
+        "capacitor": [
+          "flox",
+          "floxpkgs-internal",
+          "Curious-Ways",
+          "floxpkgs",
+          "capacitor"
+        ]
+      },
+      "locked": {
+        "lastModified": 1661869301,
+        "narHash": "sha256-LcOkB1sYNCiw0rfDR09TS4v5a2p8wm4yIBPBeuZCIu4=",
+        "owner": "flox",
+        "repo": "builtfilter",
+        "rev": "a37cb0fb1dfb752101eb2936099530872c07c956",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "builtfilter-rs",
+        "repo": "builtfilter",
+        "type": "github"
+      }
+    },
+    "builtfilter_4": {
+      "inputs": {
+        "capacitor": [
+          "flox",
+          "floxpkgs-internal",
+          "capacitor"
+        ]
+      },
+      "locked": {
+        "lastModified": 1661869301,
+        "narHash": "sha256-LcOkB1sYNCiw0rfDR09TS4v5a2p8wm4yIBPBeuZCIu4=",
+        "ref": "builtfilter-rs",
+        "rev": "a37cb0fb1dfb752101eb2936099530872c07c956",
+        "revCount": 18,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/builtfilter"
+      },
+      "original": {
+        "ref": "builtfilter-rs",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/builtfilter"
+      }
+    },
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
     "capacitor": {
       "inputs": {
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1670518248,
-        "narHash": "sha256-4AKHnJtTamu2hjNyd3NYcD0tF3YP70IT1IQjNTcQNa8=",
+        "lastModified": 1672529069,
+        "narHash": "sha256-0ba3tVlz209TjTE2lW9/9HgxLj5XDn1nciep4mWkg68=",
         "owner": "flox",
         "repo": "capacitor",
-        "rev": "8c7f64d7231f45ea6540d79b6bd9572fb8ac6d1e",
+        "rev": "84e89c5458abaf6d5c97ed93c8e554a003359af1",
         "type": "github"
       },
       "original": {
@@ -64,6 +138,7 @@
     },
     "capacitor_2": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
@@ -72,6 +147,20 @@
         "owner": "flox",
         "repo": "capacitor",
         "rev": "8c7f64d7231f45ea6540d79b6bd9572fb8ac6d1e",
+=======
+        "nixpkgs": "nixpkgs_2",
+        "root": [
+          "flox",
+          "floxpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1665065733,
+        "narHash": "sha256-rc3RbwGSkcvhW/UUQ+CzoY/C66yPlTIlwv8M+m4NHvo=",
+        "owner": "flox",
+        "repo": "capacitor",
+        "rev": "830a026092dbed052442af65f0a5f03a458076e5",
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
         "type": "github"
       },
       "original": {
@@ -80,6 +169,106 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
+=======
+    "capacitor_3": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_4",
+        "root": [
+          "flox",
+          "floxpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1665065733,
+        "narHash": "sha256-rc3RbwGSkcvhW/UUQ+CzoY/C66yPlTIlwv8M+m4NHvo=",
+        "owner": "flox",
+        "repo": "capacitor",
+        "rev": "830a026092dbed052442af65f0a5f03a458076e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "v0",
+        "repo": "capacitor",
+        "type": "github"
+      }
+    },
+    "capacitor_4": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_6",
+        "root": [
+          "flox",
+          "floxpkgs-internal",
+          "Curious-Ways",
+          "floxpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1665065733,
+        "narHash": "sha256-rc3RbwGSkcvhW/UUQ+CzoY/C66yPlTIlwv8M+m4NHvo=",
+        "owner": "flox",
+        "repo": "capacitor",
+        "rev": "830a026092dbed052442af65f0a5f03a458076e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "repo": "capacitor",
+        "type": "github"
+      }
+    },
+    "capacitor_5": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_8",
+        "root": [
+          "flox",
+          "floxpkgs-internal",
+          "Curious-Ways",
+          "floxpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1663842328,
+        "narHash": "sha256-5reuwp2isWjw7Q2c/cM2f/k408AyuHj5wDuMJpD7lSI=",
+        "owner": "flox",
+        "repo": "capacitor",
+        "rev": "1133de9277a703ff2009628fa641989283b088c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "v0",
+        "repo": "capacitor",
+        "type": "github"
+      }
+    },
+    "capacitor_6": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_9",
+        "root": [
+          "flox",
+          "floxpkgs-internal"
+        ]
+      },
+      "locked": {
+        "lastModified": 1665065733,
+        "narHash": "sha256-rc3RbwGSkcvhW/UUQ+CzoY/C66yPlTIlwv8M+m4NHvo=",
+        "ref": "v0",
+        "rev": "830a026092dbed052442af65f0a5f03a458076e5",
+        "revCount": 23,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/capacitor"
+      },
+      "original": {
+        "ref": "v0",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/capacitor"
+      }
+    },
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
     "catalog": {
       "flake": false,
       "locked": {
@@ -114,6 +303,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "flox": {
       "inputs": {
         "flox-floxpkgs": "flox-floxpkgs"
@@ -161,14 +351,310 @@
         "floxpkgs": [
           "flox",
           "flox-floxpkgs"
+=======
+    "catalog_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1665076737,
+        "narHash": "sha256-S0bD7Z434Lvm7U4VHwvmxdTMrexdr72Yk6z0ExE3j7s=",
+        "owner": "flox",
+        "repo": "floxpkgs",
+        "rev": "bd8326c2fea27d01933eacb922f5ae70f97140c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "publish",
+        "repo": "floxpkgs",
+        "type": "github"
+      }
+    },
+    "catalog_4": {
+      "inputs": {
+        "capacitor": [
+          "flox",
+          "floxpkgs-internal",
+          "capacitor"
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
         ]
       },
       "locked": {
-        "lastModified": 1670439320,
-        "narHash": "sha256-fYoEKHnWDS6TJJMUI1ft4VLE+ZL1FZtadOwxAGZEdZE=",
+        "lastModified": 1657575064,
+        "narHash": "sha256-DWjV9XtwjzihLPwL3ZZ6JRNG92OQ7oSCpH9JMwFpaIs=",
+        "ref": "master",
+        "rev": "2dcde6d52f6bf846be475a3653c01d07de4f0919",
+        "revCount": 53,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/catalog"
+      },
+      "original": {
+        "ref": "master",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/catalog"
+      }
+    },
+    "devshell": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "flox",
+          "floxpkgs-internal",
+          "Curious-Ways",
+          "floxpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1663445644,
+        "narHash": "sha256-+xVlcK60x7VY1vRJbNUEAHi17ZuoQxAIH4S4iUFUGBA=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "e3dc3e21594fe07bdb24bdf1c8657acaa4cb8f66",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "locked": {
+        "lastModified": 1667077288,
+        "narHash": "sha256-bdC8sFNDpT0HK74u9fUkpbf1MEzVYJ+ka7NXCdgBoaA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "6ee9ebb6b1ee695d2cacc4faa053a7b9baa76817",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flox": {
+      "inputs": {
+        "floxpkgs": "floxpkgs",
+        "floxpkgs-internal": "floxpkgs-internal",
+        "shellHooks": "shellHooks"
+      },
+      "locked": {
+        "lastModified": 1668803842,
+        "narHash": "sha256-DIrXAHnffwOJGopfI06Mkq/hWvzae+UMFfjeIu9nbLQ=",
+        "ref": "refs/heads/main",
+        "rev": "531318ed5c06fb9fbd30defdfb559161eaf3838b",
+        "revCount": 165,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox"
+      },
+      "original": {
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox"
+      }
+    },
+    "flox-extras": {
+      "inputs": {
+        "capacitor": [
+          "flox",
+          "floxpkgs",
+          "capacitor"
+        ]
+      },
+      "locked": {
+        "lastModified": 1668451839,
+        "narHash": "sha256-3+2tbchvoHC3W0Ex99/sDq4E+fWOWu2p33y0/eIVqbM=",
+        "owner": "flox",
+        "repo": "flox-extras",
+        "rev": "dd7569dd8c0c38d5198835a93bbcfd25549ef31e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "repo": "flox-extras",
+        "type": "github"
+      }
+    },
+    "flox-extras_2": {
+      "inputs": {
+        "capacitor": [
+          "flox",
+          "floxpkgs-internal",
+          "Curious-Ways",
+          "floxpkgs",
+          "capacitor"
+        ]
+      },
+      "locked": {
+        "lastModified": 1665157056,
+        "narHash": "sha256-iBs3/ekRdNCFI4VClOXaibLZMHp1f76zmL5DaKfWJVY=",
+        "owner": "flox",
+        "repo": "flox-extras",
+        "rev": "3241fb149e3107fb0b69600eb2095fb2976461e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "repo": "flox-extras",
+        "type": "github"
+      }
+    },
+    "flox-extras_3": {
+      "inputs": {
+        "capacitor": [
+          "flox",
+          "floxpkgs-internal",
+          "capacitor"
+        ]
+      },
+      "locked": {
+        "lastModified": 1668451839,
+        "narHash": "sha256-3+2tbchvoHC3W0Ex99/sDq4E+fWOWu2p33y0/eIVqbM=",
+        "ref": "master",
+        "rev": "dd7569dd8c0c38d5198835a93bbcfd25549ef31e",
+        "revCount": 36,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox-extras"
+      },
+      "original": {
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox-extras"
+      }
+    },
+    "flox-internal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668535531,
+        "narHash": "sha256-R+bKL5wMPLG5y+DD4oY6mNErjVl0+4rFdef80ofPPEw=",
         "ref": "main",
-        "rev": "8773bf45bae559705c996c6a88cbe86849a926b9",
-        "revCount": 92,
+        "rev": "2052fa4c6d2bd34f2c03e48a22199e12660a3f2a",
+        "revCount": 59,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox-internal"
+      },
+      "original": {
+        "ref": "main",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox-internal"
+      }
+    },
+    "flox-rust-sdk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668647579,
+        "narHash": "sha256-R1PhhNFUkoSyBT6MuqSOzVdR1lKvTh/qog09N91kksc=",
+        "ref": "develop",
+        "rev": "a1d01fa99157546bd2afeb17ff27a30744b45d62",
+        "revCount": 160,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox-rust-sdk"
+      },
+      "original": {
+        "ref": "develop",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox-rust-sdk"
+      }
+    },
+    "flox_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668084533,
+        "narHash": "sha256-SufyMU+Om4hC97dPuMK13cWh9MjjbNgpbLvoPo5SYIE=",
+        "ref": "main",
+        "rev": "4be046d0568e90c74231cd763b9239c8046f0f35",
+        "revCount": 58,
         "type": "git",
         "url": "ssh://git@github.com/flox/flox"
       },
@@ -176,6 +662,349 @@
         "ref": "main",
         "type": "git",
         "url": "ssh://git@github.com/flox/flox"
+      }
+    },
+    "flox_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1665065611,
+        "narHash": "sha256-IqyN3Erq9Tm33jxeZQdBu5Tyz+XQAVY+MNffrtVlnT0=",
+        "ref": "main",
+        "rev": "ef96d52f3a7a2709aa3325e29c264f665d3381ab",
+        "revCount": 31,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox"
+      },
+      "original": {
+        "ref": "main",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox"
+      }
+    },
+    "flox_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668084533,
+        "narHash": "sha256-SufyMU+Om4hC97dPuMK13cWh9MjjbNgpbLvoPo5SYIE=",
+        "ref": "main",
+        "rev": "4be046d0568e90c74231cd763b9239c8046f0f35",
+        "revCount": 58,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox"
+      },
+      "original": {
+        "ref": "main",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox"
+      }
+    },
+    "floxdocs_tng": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1667668489,
+        "narHash": "sha256-d4f8BOSCSMdI7eI2O3rW6nbzwARJC4pmj+8GHd1NuGQ=",
+        "ref": "tng",
+        "rev": "7c016a6446eb4d69d588d5543459ce82f6176772",
+        "revCount": 746,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/floxdocs"
+      },
+      "original": {
+        "ref": "tng",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/floxdocs"
+      }
+    },
+    "floxdocs_tngv3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668542971,
+        "narHash": "sha256-H8egS+MnhdUpTGTz8EX94ezGMYJajaJtKYv6SEaJ6ZQ=",
+        "ref": "tngv3",
+        "rev": "43176172be8a191f545a9cf9353150f9e2791da7",
+        "revCount": 761,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/floxdocs"
+      },
+      "original": {
+        "ref": "tngv3",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/floxdocs"
+      }
+    },
+    "floxpkgs": {
+      "inputs": {
+        "builtfilter": "builtfilter_2",
+        "capacitor": "capacitor_2",
+        "catalog": "catalog_2",
+        "flox": "flox_2",
+        "flox-extras": "flox-extras",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1668546423,
+        "narHash": "sha256-Pn6MCE0pcOQPJYOkFz/em6u5ISZBN1Av3MSfTeg6GE8=",
+        "owner": "flox",
+        "repo": "floxpkgs",
+        "rev": "cce6a555463d036bbb47fdc4cf0b47af9c3c2d77",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "repo": "floxpkgs",
+        "type": "github"
+      }
+    },
+    "floxpkgs-internal": {
+      "inputs": {
+        "Curious-Ways": "Curious-Ways",
+        "builtfilter": "builtfilter_4",
+        "capacitor": "capacitor_6",
+        "catalog": "catalog_4",
+        "flox": "flox_4",
+        "flox-extras": "flox-extras_3",
+        "flox-internal": "flox-internal",
+        "flox-rust-sdk": "flox-rust-sdk",
+        "floxdocs_tng": "floxdocs_tng",
+        "floxdocs_tngv3": "floxdocs_tngv3",
+        "mini-dinstall": "mini-dinstall",
+        "nix-editor": "nix-editor_2",
+        "nix-installers": "nix-installers",
+        "nixpkgs-stable": "nixpkgs-stable_3",
+        "nixpkgs-staging": "nixpkgs-staging_3",
+        "nixpkgs-unstable": "nixpkgs-unstable_3",
+        "self-staging": [
+          "flox",
+          "floxpkgs-internal"
+        ],
+        "self-unstable": [
+          "flox",
+          "floxpkgs-internal"
+        ],
+        "tracelinks": "tracelinks",
+        "update-catalog": "update-catalog"
+      },
+      "locked": {
+        "lastModified": 1668648056,
+        "narHash": "sha256-zd8dfIsAfq4i54Y518kDKqzWaQmOURMX423O3B24/Jk=",
+        "ref": "flox-cli",
+        "rev": "757ac2b5ee92dbe1cdae1b2b6950bbb08c3f4149",
+        "revCount": 759,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/floxpkgs-internal"
+      },
+      "original": {
+        "ref": "flox-cli",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/floxpkgs-internal"
+      }
+    },
+    "floxpkgs_2": {
+      "inputs": {
+        "builtfilter": "builtfilter_3",
+        "capacitor": "capacitor_4",
+        "catalog": "catalog_3",
+        "devshell": "devshell",
+        "flox": "flox_3",
+        "flox-extras": "flox-extras_2",
+        "mach-nix": "mach-nix",
+        "naersk": "naersk",
+        "nix-editor": "nix-editor",
+        "nixpkgs": "nixpkgs_7",
+        "pypi-deps-db": "pypi-deps-db",
+        "self-staging": [
+          "flox",
+          "floxpkgs-internal",
+          "Curious-Ways",
+          "floxpkgs"
+        ],
+        "self-unstable": [
+          "flox",
+          "floxpkgs-internal",
+          "Curious-Ways",
+          "floxpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1665157158,
+        "narHash": "sha256-Rg2FignnTXl+G6ZxCAjrG1iuc4dYkOmgnbICqR0ncl8=",
+        "owner": "flox",
+        "repo": "floxpkgs",
+        "rev": "8915d3b599c0d1a1ab91cdb91fd5b47dc79d2fc4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "repo": "floxpkgs",
+        "type": "github"
+      }
+    },
+    "mach-nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "flox",
+          "floxpkgs-internal",
+          "Curious-Ways",
+          "floxpkgs",
+          "nixpkgs"
+        ],
+        "pypi-deps-db": [
+          "flox",
+          "floxpkgs-internal",
+          "Curious-Ways",
+          "floxpkgs",
+          "pypi-deps-db"
+        ]
+      },
+      "locked": {
+        "lastModified": 1662635943,
+        "narHash": "sha256-1OBBlBzZ894or8eHZjyADOMnGH89pPUKYGVVS5rwW/0=",
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "rev": "65266b5cc867fec2cb6a25409dd7cd12251f6107",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "type": "github"
+      }
+    },
+    "mini-dinstall": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1628154387,
+        "narHash": "sha256-Xb8pO+jmMCbkgd8gcamqs2kFpBuccc7xa21jQKnCy04=",
+        "ref": "main",
+        "rev": "e0a05885120fd70595fe0f5468fa77d83049081f",
+        "revCount": 1,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/mini-dinstall"
+      },
+      "original": {
+        "ref": "main",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/mini-dinstall"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "flox",
+          "floxpkgs-internal",
+          "Curious-Ways",
+          "floxpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1662220400,
+        "narHash": "sha256-9o2OGQqu4xyLZP9K6kNe1pTHnyPz0Wr3raGYnr9AIgY=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "6944160c19cb591eb85bbf9b2f2768a935623ed3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "naersk_2": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_10"
+      },
+      "locked": {
+        "lastModified": 1662220400,
+        "narHash": "sha256-9o2OGQqu4xyLZP9K6kNe1pTHnyPz0Wr3raGYnr9AIgY=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "6944160c19cb591eb85bbf9b2f2768a935623ed3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nix-editor": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils_3",
+        "naersk": [
+          "flox",
+          "floxpkgs-internal",
+          "Curious-Ways",
+          "floxpkgs",
+          "naersk"
+        ],
+        "nixpkgs": [
+          "flox",
+          "floxpkgs-internal",
+          "Curious-Ways",
+          "floxpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1665098325,
+        "narHash": "sha256-yjiYbBJNzsG6kAS6aRbqmMyiwEimT1/wzg4MUWwzNco=",
+        "owner": "vlinkz",
+        "repo": "nix-editor",
+        "rev": "5c78e2ab8bd110e85e346f32d8a9a9ba45ccc37c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vlinkz",
+        "repo": "nix-editor",
+        "type": "github"
+      }
+    },
+    "nix-editor_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_4",
+        "naersk": "naersk_2",
+        "nixpkgs": "nixpkgs_11"
+      },
+      "locked": {
+        "lastModified": 1665098325,
+        "narHash": "sha256-yjiYbBJNzsG6kAS6aRbqmMyiwEimT1/wzg4MUWwzNco=",
+        "owner": "vlinkz",
+        "repo": "nix-editor",
+        "rev": "5c78e2ab8bd110e85e346f32d8a9a9ba45ccc37c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vlinkz",
+        "repo": "nix-editor",
+        "type": "github"
+      }
+    },
+    "nix-installers": {
+      "inputs": {
+        "capacitor": [
+          "flox",
+          "floxpkgs-internal",
+          "capacitor"
+        ]
+      },
+      "locked": {
+        "lastModified": 1668595096,
+        "narHash": "sha256-Go7MdRHru/FFdM1JtvAcj+6AonUeg7RWOShBuB9lzMk=",
+        "ref": "master",
+        "rev": "80127ffc19d9d8ac4bc66becb8db8f72138e63e0",
+        "revCount": 158,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/nix-installers"
+      },
+      "original": {
+        "ref": "master",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/nix-installers"
       }
     },
     "nixpkgs": {
@@ -196,6 +1025,54 @@
     },
     "nixpkgs-stable": {
       "locked": {
+        "lastModified": 1666703756,
+        "narHash": "sha256-GwpMJ1hT+z1fMAUkaGtvbvofJQwdVFDEGVhfE82+AUk=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "f994293d1eb8812f032e8919e10a594567cf6ef7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "stable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
+      "locked": {
+        "lastModified": 1663761423,
+        "narHash": "sha256-bDLXl2BVq7eIQz/8CduZI1SLyhG9u/CrckHd6f7bwPE=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "d6490a0bd9dfb298fcd8382d3363b86870dc7340",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "stable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_3": {
+      "locked": {
+        "lastModified": 1666703756,
+        "narHash": "sha256-GwpMJ1hT+z1fMAUkaGtvbvofJQwdVFDEGVhfE82+AUk=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "f994293d1eb8812f032e8919e10a594567cf6ef7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "stable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_4": {
+      "locked": {
         "lastModified": 1669140675,
         "narHash": "sha256-npzfyfLECsJWgzK/M4gWhykP2DNAJTYjgY2BWkz/oEQ=",
         "owner": "flox",
@@ -212,6 +1089,7 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1669140675,
         "narHash": "sha256-npzfyfLECsJWgzK/M4gWhykP2DNAJTYjgY2BWkz/oEQ=",
         "owner": "flox",
@@ -233,6 +1111,13 @@
         "owner": "flox",
         "repo": "nixpkgs",
         "rev": "1710ed1f6f8ceb75cf7d1cf55ee0cc21760e1c7a",
+=======
+        "lastModified": 1667901915,
+        "narHash": "sha256-IkSou5ox/yZ2YUhGpk8vxd2TNU2pwRlYtir5k55NaxE=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "093268502280540a7f5bf1e2a6330a598ba3b7d0",
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
         "type": "github"
       },
       "original": {
@@ -244,6 +1129,41 @@
     },
     "nixpkgs-staging_2": {
       "locked": {
+<<<<<<< HEAD
+=======
+        "lastModified": 1663761423,
+        "narHash": "sha256-bDLXl2BVq7eIQz/8CduZI1SLyhG9u/CrckHd6f7bwPE=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "d6490a0bd9dfb298fcd8382d3363b86870dc7340",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "staging",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-staging_3": {
+      "locked": {
+        "lastModified": 1667901915,
+        "narHash": "sha256-IkSou5ox/yZ2YUhGpk8vxd2TNU2pwRlYtir5k55NaxE=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "093268502280540a7f5bf1e2a6330a598ba3b7d0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "staging",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-staging_4": {
+      "locked": {
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
         "lastModified": 1671983799,
         "narHash": "sha256-Z2Ro6hFPZHkBqkVXY5/aBUzxi5xizQGvuHQ9+T5B/ks=",
         "owner": "flox",
@@ -260,6 +1180,7 @@
     },
     "nixpkgs-unstable": {
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1671359686,
         "narHash": "sha256-3MpC6yZo+Xn9cPordGz2/ii6IJpP2n8LE8e/ebUXLrs=",
         "owner": "flox",
@@ -281,6 +1202,13 @@
         "owner": "flox",
         "repo": "nixpkgs",
         "rev": "fad51abd42ca17a60fc1d4cb9382e2d79ae31836",
+=======
+        "lastModified": 1667901915,
+        "narHash": "sha256-IkSou5ox/yZ2YUhGpk8vxd2TNU2pwRlYtir5k55NaxE=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "093268502280540a7f5bf1e2a6330a598ba3b7d0",
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
         "type": "github"
       },
       "original": {
@@ -290,6 +1218,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1669140675,
@@ -297,15 +1226,29 @@
         "owner": "flox",
         "repo": "nixpkgs",
         "rev": "2788904d26dda6cfa1921c5abb7a2466ffe3cb8c",
+=======
+    "nixpkgs-unstable_2": {
+      "locked": {
+        "lastModified": 1663761423,
+        "narHash": "sha256-bDLXl2BVq7eIQz/8CduZI1SLyhG9u/CrckHd6f7bwPE=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "d6490a0bd9dfb298fcd8382d3363b86870dc7340",
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
         "type": "github"
       },
       "original": {
         "owner": "flox",
+<<<<<<< HEAD
         "ref": "stable",
+=======
+        "ref": "unstable",
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
         "repo": "nixpkgs",
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "nixpkgs_3": {
       "inputs": {
         "floxpkgs": [
@@ -328,6 +1271,89 @@
         "owner": "flox",
         "repo": "nixpkgs-flox",
         "rev": "6b1573bd94dc036a7c67c3c5b5fc35221e336025",
+=======
+    "nixpkgs-unstable_3": {
+      "locked": {
+        "lastModified": 1667901915,
+        "narHash": "sha256-IkSou5ox/yZ2YUhGpk8vxd2TNU2pwRlYtir5k55NaxE=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "093268502280540a7f5bf1e2a6330a598ba3b7d0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_4": {
+      "locked": {
+        "lastModified": 1671983799,
+        "narHash": "sha256-Z2Ro6hFPZHkBqkVXY5/aBUzxi5xizQGvuHQ9+T5B/ks=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "fad51abd42ca17a60fc1d4cb9382e2d79ae31836",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_10": {
+      "locked": {
+        "lastModified": 1664847737,
+        "narHash": "sha256-Wxl0CtRH3Vo8+qEZ/PbCcx+9D8wEEi56tJPmROum2ss=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "de80d1d04ee691279e1302a1128c082bbda3ab01",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_11": {
+      "locked": {
+        "lastModified": 1664780719,
+        "narHash": "sha256-Oxe6la5dSqRfJogjtY4sRzJjDDqvroJIVkcGEOT87MA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "fd54651f5ffb4a36e8463e0c327a78442b26cbe7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_12": {
+      "inputs": {
+        "floxpkgs": [],
+        "nixpkgs": "nixpkgs_13",
+        "nixpkgs-stable": "nixpkgs-stable_4",
+        "nixpkgs-staging": "nixpkgs-staging_4",
+        "nixpkgs-unstable": "nixpkgs-unstable_4",
+        "nixpkgs__catalog__aarch64-darwin": "nixpkgs__catalog__aarch64-darwin_3",
+        "nixpkgs__catalog__aarch64-linux": "nixpkgs__catalog__aarch64-linux_3",
+        "nixpkgs__catalog__i686-linux": "nixpkgs__catalog__i686-linux",
+        "nixpkgs__catalog__x86_64-darwin": "nixpkgs__catalog__x86_64-darwin_3",
+        "nixpkgs__catalog__x86_64-linux": "nixpkgs__catalog__x86_64-linux_3"
+      },
+      "locked": {
+        "lastModified": 1672488811,
+        "narHash": "sha256-Ti+N9M0+ut60jilGJHk8+SA9+BlBsACmfwz11T6jGiE=",
+        "owner": "flox",
+        "repo": "nixpkgs-flox",
+        "rev": "eeabd89e94a93a2cb3e3222692914f625912960c",
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
         "type": "github"
       },
       "original": {
@@ -336,6 +1362,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "nixpkgs_4": {
       "locked": {
         "lastModified": 1669140675,
@@ -380,6 +1407,9 @@
       }
     },
     "nixpkgs_6": {
+=======
+    "nixpkgs_13": {
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
       "locked": {
         "lastModified": 1669140675,
         "narHash": "sha256-npzfyfLECsJWgzK/M4gWhykP2DNAJTYjgY2BWkz/oEQ=",
@@ -395,15 +1425,190 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1666703756,
+        "narHash": "sha256-GwpMJ1hT+z1fMAUkaGtvbvofJQwdVFDEGVhfE82+AUk=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "f994293d1eb8812f032e8919e10a594567cf6ef7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "stable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "inputs": {
+        "capacitor": "capacitor_3",
+        "flox-extras": [
+          "flox",
+          "floxpkgs",
+          "flox-extras"
+        ],
+        "nixpkgs": "nixpkgs_5",
+        "nixpkgs-stable": "nixpkgs-stable",
+        "nixpkgs-staging": "nixpkgs-staging",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "nixpkgs__catalog__aarch64-darwin": "nixpkgs__catalog__aarch64-darwin",
+        "nixpkgs__catalog__aarch64-linux": "nixpkgs__catalog__aarch64-linux",
+        "nixpkgs__catalog__x86_64-darwin": "nixpkgs__catalog__x86_64-darwin",
+        "nixpkgs__catalog__x86_64-linux": "nixpkgs__catalog__x86_64-linux"
+      },
+      "locked": {
+        "lastModified": 1668256109,
+        "narHash": "sha256-2kgMtY+PUjhfSmgQiiXZlWb8TmepHpOGTuV+5iKU1lc=",
+        "owner": "flox",
+        "repo": "nixpkgs-flox",
+        "rev": "16a9b5beaaf38ffa33d732e315877dbece937fdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "repo": "nixpkgs-flox",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1666703756,
+        "narHash": "sha256-GwpMJ1hT+z1fMAUkaGtvbvofJQwdVFDEGVhfE82+AUk=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "f994293d1eb8812f032e8919e10a594567cf6ef7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "stable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1666703756,
+        "narHash": "sha256-GwpMJ1hT+z1fMAUkaGtvbvofJQwdVFDEGVhfE82+AUk=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "f994293d1eb8812f032e8919e10a594567cf6ef7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "stable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
+        "lastModified": 1663761423,
+        "narHash": "sha256-bDLXl2BVq7eIQz/8CduZI1SLyhG9u/CrckHd6f7bwPE=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "d6490a0bd9dfb298fcd8382d3363b86870dc7340",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "stable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
+      "inputs": {
+        "capacitor": "capacitor_5",
+        "flox-extras": [
+          "flox",
+          "floxpkgs-internal",
+          "Curious-Ways",
+          "floxpkgs",
+          "flox-extras"
+        ],
+        "nixpkgs": [
+          "flox",
+          "floxpkgs-internal",
+          "Curious-Ways",
+          "floxpkgs",
+          "nixpkgs",
+          "nixpkgs-stable"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable_2",
+        "nixpkgs-staging": "nixpkgs-staging_2",
+        "nixpkgs-unstable": "nixpkgs-unstable_2",
+        "nixpkgs__catalog__aarch64-darwin": "nixpkgs__catalog__aarch64-darwin_2",
+        "nixpkgs__catalog__aarch64-linux": "nixpkgs__catalog__aarch64-linux_2",
+        "nixpkgs__catalog__x86_64-darwin": "nixpkgs__catalog__x86_64-darwin_2",
+        "nixpkgs__catalog__x86_64-linux": "nixpkgs__catalog__x86_64-linux_2"
+      },
+      "locked": {
+        "lastModified": 1664811165,
+        "narHash": "sha256-nsChD0EqMTVb/+O0ZxYGT3pvtZn/ceHIN/czHwJHemI=",
+        "owner": "flox",
+        "repo": "nixpkgs-flox",
+        "rev": "54380b5570d3abaf55ac24139e7aa9cfb4e0b0f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "repo": "nixpkgs-flox",
+        "type": "github"
+      }
+    },
+    "nixpkgs_8": {
+      "locked": {
+        "lastModified": 1663761423,
+        "narHash": "sha256-bDLXl2BVq7eIQz/8CduZI1SLyhG9u/CrckHd6f7bwPE=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "d6490a0bd9dfb298fcd8382d3363b86870dc7340",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "stable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1666703756,
+        "narHash": "sha256-GwpMJ1hT+z1fMAUkaGtvbvofJQwdVFDEGVhfE82+AUk=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "f994293d1eb8812f032e8919e10a594567cf6ef7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "stable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs__catalog__aarch64-darwin": {
       "flake": false,
       "locked": {
+<<<<<<< HEAD
         "host": "catalog.floxsdlc.com",
         "lastModified": 1671273983,
         "narHash": "sha256-GBt+MpzDybUKfB8ikXsGXnUu+/4osnbyeGsimICo8Z8=",
         "owner": "flox",
         "repo": "nixpkgs-catalog",
         "rev": "5c5f30fe4580df5b3d57222b94c054b46ca78869",
+=======
+        "lastModified": 1668255984,
+        "narHash": "sha256-xln6Lju1JTTKOOTntyYswjIXeM7Vu8g2K2FUxy9mRBQ=",
+        "owner": "flox",
+        "repo": "nixpkgs-catalog",
+        "rev": "de000a864c01dc768d73d68436e91e46e611e970",
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
         "type": "github"
       },
       "original": {
@@ -433,15 +1638,59 @@
         "type": "github"
       }
     },
+    "nixpkgs__catalog__aarch64-darwin_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1664567261,
+        "narHash": "sha256-1U6lEB03FZFDzxEJ06rxVRPsoWoxAOtrWaak1kKiXnU=",
+        "owner": "flox",
+        "repo": "nixpkgs-catalog",
+        "rev": "4ec18e0a4485552c6b328c6c4f25238a04b60b49",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "aarch64-darwin",
+        "repo": "nixpkgs-catalog",
+        "type": "github"
+      }
+    },
+    "nixpkgs__catalog__aarch64-darwin_3": {
+      "flake": false,
+      "locked": {
+        "host": "catalog.floxsdlc.com",
+        "lastModified": 1671273983,
+        "narHash": "sha256-GBt+MpzDybUKfB8ikXsGXnUu+/4osnbyeGsimICo8Z8=",
+        "owner": "flox",
+        "repo": "nixpkgs-catalog",
+        "rev": "5c5f30fe4580df5b3d57222b94c054b46ca78869",
+        "type": "github"
+      },
+      "original": {
+        "host": "catalog.floxsdlc.com",
+        "owner": "flox",
+        "ref": "aarch64-darwin",
+        "repo": "nixpkgs-catalog",
+        "type": "github"
+      }
+    },
     "nixpkgs__catalog__aarch64-linux": {
       "flake": false,
       "locked": {
+<<<<<<< HEAD
         "host": "catalog.floxsdlc.com",
         "lastModified": 1671273964,
         "narHash": "sha256-kiJP3SZyS9vPQtFQ63PK8R6CaQJtZHAcF8BhgJs+Oec=",
         "owner": "flox",
         "repo": "nixpkgs-catalog",
         "rev": "5b889868276def7663b97ae0fb572a549b18587b",
+=======
+        "lastModified": 1668255974,
+        "narHash": "sha256-HU7V/WxQrV4ogvJzj/WUZDC2mRuV4YvXulaKzhyq6Lo=",
+        "owner": "flox",
+        "repo": "nixpkgs-catalog",
+        "rev": "2e9c7201a0671265daf82d04e7c4befd3c152578",
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
         "type": "github"
       },
       "original": {
@@ -455,6 +1704,26 @@
     "nixpkgs__catalog__aarch64-linux_2": {
       "flake": false,
       "locked": {
+<<<<<<< HEAD
+=======
+        "lastModified": 1664565009,
+        "narHash": "sha256-zuF8pRZF01RFkwB4sgMsbYG3tAKxncfNxp11RrNYMFc=",
+        "owner": "flox",
+        "repo": "nixpkgs-catalog",
+        "rev": "d9bb6f7f5af94f3d109ed74fb66a38c1f16b0024",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "aarch64-linux",
+        "repo": "nixpkgs-catalog",
+        "type": "github"
+      }
+    },
+    "nixpkgs__catalog__aarch64-linux_3": {
+      "flake": false,
+      "locked": {
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
         "host": "catalog.floxsdlc.com",
         "lastModified": 1671273964,
         "narHash": "sha256-kiJP3SZyS9vPQtFQ63PK8R6CaQJtZHAcF8BhgJs+Oec=",
@@ -490,6 +1759,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "nixpkgs__catalog__i686-linux_2": {
       "flake": false,
       "locked": {
@@ -518,6 +1788,16 @@
         "owner": "flox",
         "repo": "nixpkgs-catalog",
         "rev": "f56a63d01060dd51e1419273d6a5f54b18082130",
+=======
+    "nixpkgs__catalog__x86_64-darwin": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668256035,
+        "narHash": "sha256-VQEYIQNeCTtA+WOf60M/uFT5zWXT759yyjdGv4dVc9g=",
+        "owner": "flox",
+        "repo": "nixpkgs-catalog",
+        "rev": "a907132e61bb9f3daf8fcb6f7fc8fe875177cbf9",
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
         "type": "github"
       },
       "original": {
@@ -547,15 +1827,59 @@
         "type": "github"
       }
     },
+    "nixpkgs__catalog__x86_64-darwin_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1663927982,
+        "narHash": "sha256-Zsu8FtuQ4o5NtJVCPzxJI5KNggElD/2F9AD+A1mh9nU=",
+        "owner": "flox",
+        "repo": "nixpkgs-catalog",
+        "rev": "d0c41ddb95681407cdb96d3d7ac05fd800978a42",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "x86_64-darwin",
+        "repo": "nixpkgs-catalog",
+        "type": "github"
+      }
+    },
+    "nixpkgs__catalog__x86_64-darwin_3": {
+      "flake": false,
+      "locked": {
+        "host": "catalog.floxsdlc.com",
+        "lastModified": 1671274054,
+        "narHash": "sha256-baL8XKl95HijEINrIdixQwgrYM6Yuav6gutTNpQ0piU=",
+        "owner": "flox",
+        "repo": "nixpkgs-catalog",
+        "rev": "f56a63d01060dd51e1419273d6a5f54b18082130",
+        "type": "github"
+      },
+      "original": {
+        "host": "catalog.floxsdlc.com",
+        "owner": "flox",
+        "ref": "x86_64-darwin",
+        "repo": "nixpkgs-catalog",
+        "type": "github"
+      }
+    },
     "nixpkgs__catalog__x86_64-linux": {
       "flake": false,
       "locked": {
+<<<<<<< HEAD
         "host": "catalog.floxsdlc.com",
         "lastModified": 1671274034,
         "narHash": "sha256-GCoYIZwps744A6nmyckEC3M9lyUL2Hb6htPawbgXrbQ=",
         "owner": "flox",
         "repo": "nixpkgs-catalog",
         "rev": "34f740ae04900cdcd8f9f90b0b869b75932358c2",
+=======
+        "lastModified": 1668256025,
+        "narHash": "sha256-nzv7ZEPqA9oOaCsf/l0s+rLjvjs8ef6xBXU2ykFBeAc=",
+        "owner": "flox",
+        "repo": "nixpkgs-catalog",
+        "rev": "0c85325e8800657871a3694602374e16c0d5d30e",
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
         "type": "github"
       },
       "original": {
@@ -585,17 +1909,115 @@
         "type": "github"
       }
     },
+    "nixpkgs__catalog__x86_64-linux_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1664568655,
+        "narHash": "sha256-Kgsyx8twJVRlCZ4gNmD8gu2CYHnhb1xseXWyQKmeCRQ=",
+        "owner": "flox",
+        "repo": "nixpkgs-catalog",
+        "rev": "014103b6c34b1d640cb5499530c94789f58d0932",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "x86_64-linux",
+        "repo": "nixpkgs-catalog",
+        "type": "github"
+      }
+    },
+    "nixpkgs__catalog__x86_64-linux_3": {
+      "flake": false,
+      "locked": {
+        "host": "catalog.floxsdlc.com",
+        "lastModified": 1671274034,
+        "narHash": "sha256-GCoYIZwps744A6nmyckEC3M9lyUL2Hb6htPawbgXrbQ=",
+        "owner": "flox",
+        "repo": "nixpkgs-catalog",
+        "rev": "34f740ae04900cdcd8f9f90b0b869b75932358c2",
+        "type": "github"
+      },
+      "original": {
+        "host": "catalog.floxsdlc.com",
+        "owner": "flox",
+        "ref": "x86_64-linux",
+        "repo": "nixpkgs-catalog",
+        "type": "github"
+      }
+    },
+    "pypi-deps-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1665131977,
+        "narHash": "sha256-CQo8yGrvCvSeLpOSXBr7P/cF/b3AzynMKKBqXkJkGdw=",
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "rev": "df7e22b1991ef14d402beb7e0852a89d7e2e50af",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "builtfilter": "builtfilter",
         "capacitor": "capacitor",
         "catalog": "catalog",
         "flox": "flox",
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_5",
+        "tracelinks": "tracelinks_2"
+=======
+        "nixpkgs": "nixpkgs_12",
         "tracelinks": "tracelinks_2"
       }
     },
+    "shellHooks": {
+      "inputs": {
+        "flake-utils": "flake-utils_5",
+        "nixpkgs": [
+          "flox",
+          "floxpkgs",
+          "nixpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1667992213,
+        "narHash": "sha256-8Ens8ozllvlaFMCZBxg6S7oUyynYx2v7yleC5M0jJsE=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "ebcbfe09d2bd6d15f68de3a0ebb1e4dcb5cd324b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+>>>>>>> 5c401df (feat: use lib.flox-floxpkgs.getRev)
+      }
+    },
     "tracelinks": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647596882,
+        "narHash": "sha256-RdD0fUS1XT03T4XSp4abxb8AOkQUEy93I86xBkks/Tc=",
+        "ref": "main",
+        "rev": "22d985d2757f1834ee51d3dadc93908c9cfc9ab3",
+        "revCount": 5,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/tracelinks"
+      },
+      "original": {
+        "ref": "main",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/tracelinks"
+      }
+    },
+    "tracelinks_2": {
       "inputs": {
         "floxpkgs": [
           "flox",
@@ -622,18 +2044,34 @@
         "floxpkgs": []
       },
       "locked": {
-        "lastModified": 1669919769,
+        "lastModified": 1669934358,
         "narHash": "sha256-BxN0D6q2p8B46I7EiKdZRf7zfoIy+E+tLnVNyK/sWDY=",
-        "ref": "fix/overlay-trees",
-        "rev": "825088723474ed7e6b93b19a2305500b4222a670",
+        "ref": "refs/heads/main",
+        "rev": "317a48f29ca13277b6be0f127820163304fef778",
         "revCount": 8,
         "type": "git",
         "url": "ssh://git@github.com/flox/tracelinks"
       },
       "original": {
-        "ref": "fix/overlay-trees",
         "type": "git",
         "url": "ssh://git@github.com/flox/tracelinks"
+      }
+    },
+    "update-catalog": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1667305787,
+        "narHash": "sha256-NLsfvH4DvhP5DtNNIOSPDv+WYscoEPQB6+C1vypvicE=",
+        "ref": "main",
+        "rev": "a60d6a148010c8e8fef699733bef3ceda26afeea",
+        "revCount": 88,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/update-catalog"
+      },
+      "original": {
+        "ref": "main",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/update-catalog"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -14,9 +14,9 @@
   # =================================
 
   inputs.flox.url = "git+ssh://git@github.com/flox/flox-bash?ref=main";
-  inputs.flox.inputs.floxpkgs.follows = "/";
+  inputs.flox.inputs.flox-floxpkgs.follows = "/";
 
-  inputs.tracelinks.url = "git+ssh://git@github.com/flox/tracelinks?ref=fix/overlay-trees";
+  inputs.tracelinks.url = "git+ssh://git@github.com/flox/tracelinks";
   inputs.tracelinks.inputs.floxpkgs.follows = "/";
 
   inputs.builtfilter.url = "github:flox/builtfilter?ref=builtfilter-rs";

--- a/lib/withRevision.nix
+++ b/lib/withRevision.nix
@@ -1,0 +1,7 @@
+{}: src: version: let
+  prefix =
+    if src ? revCount
+    then "r"
+    else "";
+  revision = src.revCount or src.shortRev or "dirty";
+in "${version}-${prefix}${toString revision}"

--- a/lib/withRevision.nix
+++ b/lib/withRevision.nix
@@ -1,7 +1,0 @@
-{}: src: version: let
-  prefix =
-    if src ? revCount
-    then "r"
-    else "";
-  revision = src.revCount or src.shortRev or "dirty";
-in "${version}-${prefix}${toString revision}"

--- a/templates/buildBazelPackage/files/pkgs/default.nix
+++ b/templates/buildBazelPackage/files/pkgs/default.nix
@@ -2,11 +2,11 @@
   self,
   lib,
   buildBazelPackage,
-  withRev
+  inputs,
 }:
 buildBazelPackage rec {
   pname = "my-package";
-  version = withRev "0.0.0";
+  version = "0.0.0-${inputs.flox-floxpkgs.lib.getRev self}";
   src = self; # + "/src";
 
   bazelTarget = "main:my-package";

--- a/templates/buildBazelPackage/files/pkgs/default.nix
+++ b/templates/buildBazelPackage/files/pkgs/default.nix
@@ -2,10 +2,11 @@
   self,
   lib,
   buildBazelPackage,
+  withRev
 }:
 buildBazelPackage rec {
   pname = "my-package";
-  version = "0.0.0";
+  version = withRev "0.0.0";
   src = self; # + "/src";
 
   bazelTarget = "main:my-package";

--- a/templates/buildBazelPackage/files/pkgs/default.nix
+++ b/templates/buildBazelPackage/files/pkgs/default.nix
@@ -2,11 +2,10 @@
   self,
   lib,
   buildBazelPackage,
-  inputs,
 }:
 buildBazelPackage rec {
   pname = "my-package";
-  version = "0.0.0-${inputs.flox-floxpkgs.lib.getRev self}";
+  version = "0.0.0-${lib.flox-floxpkgs.getRev self}";
   src = self; # + "/src";
 
   bazelTarget = "main:my-package";

--- a/templates/buildGoModule/files/pkgs/default.nix
+++ b/templates/buildGoModule/files/pkgs/default.nix
@@ -1,12 +1,11 @@
 {
   self,
   buildGoModule,
-  lib,
-  withRev
+  inputs,
 }:
 buildGoModule {
   pname = "my-package";
-  version = withRev "0.0.0";
+  version = "0.0.0-${inputs.flox-floxpkgs.lib.getRev self}";
   src = self; # + "/src";
   # vendorSha256 should be set to null if dependencies are vendored. If the dependencies aren't
   # vendored, vendorSha256 must be set to a hash of the content of all dependencies. This hash can

--- a/templates/buildGoModule/files/pkgs/default.nix
+++ b/templates/buildGoModule/files/pkgs/default.nix
@@ -1,11 +1,11 @@
 {
   self,
   buildGoModule,
-  inputs,
+  lib,
 }:
 buildGoModule {
   pname = "my-package";
-  version = "0.0.0-${inputs.flox-floxpkgs.lib.getRev self}";
+  version = "0.0.0-${lib.flox-floxpkgs.getRev self}";
   src = self; # + "/src";
   # vendorSha256 should be set to null if dependencies are vendored. If the dependencies aren't
   # vendored, vendorSha256 must be set to a hash of the content of all dependencies. This hash can

--- a/templates/buildGoModule/files/pkgs/default.nix
+++ b/templates/buildGoModule/files/pkgs/default.nix
@@ -2,10 +2,11 @@
   self,
   buildGoModule,
   lib,
+  withRev
 }:
 buildGoModule {
   pname = "my-package";
-  version = "0.0.0";
+  version = withRev "0.0.0";
   src = self; # + "/src";
   # vendorSha256 should be set to null if dependencies are vendored. If the dependencies aren't
   # vendored, vendorSha256 must be set to a hash of the content of all dependencies. This hash can

--- a/templates/buildPerlPackage/files/pkgs/default.nix
+++ b/templates/buildPerlPackage/files/pkgs/default.nix
@@ -1,12 +1,11 @@
 {
   self,
-  lib,
   perlPackages,
-  withRev
+  inputs,
 }:
 perlPackages.buildPerlPackage rec {
-  pname = withRev "my-package";
-  version = "0.0.0";
+  pname = "my-package";
+  version = "0.0.0-${inputs.flox-flxopkgs.lib.getRev self}";
   src = self; # + "/src";
 
   outputs = ["out"];

--- a/templates/buildPerlPackage/files/pkgs/default.nix
+++ b/templates/buildPerlPackage/files/pkgs/default.nix
@@ -2,9 +2,10 @@
   self,
   lib,
   perlPackages,
+  withRev
 }:
 perlPackages.buildPerlPackage rec {
-  pname = "my-package";
+  pname = withRev "my-package";
   version = "0.0.0";
   src = self; # + "/src";
 

--- a/templates/buildPerlPackage/files/pkgs/default.nix
+++ b/templates/buildPerlPackage/files/pkgs/default.nix
@@ -1,11 +1,11 @@
 {
   self,
   perlPackages,
-  inputs,
+  lib,
 }:
 perlPackages.buildPerlPackage rec {
   pname = "my-package";
-  version = "0.0.0-${inputs.flox-flxopkgs.lib.getRev self}";
+  version = "0.0.0-${lib.flox-floxpkgs.getRev self}";
   src = self; # + "/src";
 
   outputs = ["out"];

--- a/templates/buildPythonPackage/files/pkgs/default.nix
+++ b/templates/buildPythonPackage/files/pkgs/default.nix
@@ -1,7 +1,7 @@
-{self, python3Packages}:
+{self, python3Packages, withRev}:
 python3Packages.buildPythonPackage {
   pname = "my-package";
-  version = "0.0.0";
+  version = withRev "0.0.0";
   src = self; # + "/src";
   PIP_DISABLE_PIP_VERSION_CHECK = 1;
   # Add Python modules needed by your package here

--- a/templates/buildPythonPackage/files/pkgs/default.nix
+++ b/templates/buildPythonPackage/files/pkgs/default.nix
@@ -1,7 +1,11 @@
-{self, python3Packages, withRev}:
+{
+  self,
+  python3Packages,
+  inputs,
+}:
 python3Packages.buildPythonPackage {
   pname = "my-package";
-  version = withRev "0.0.0";
+  version = "0.0.0-${inputs.flox-floxpkgs.lib.getRev self}";
   src = self; # + "/src";
   PIP_DISABLE_PIP_VERSION_CHECK = 1;
   # Add Python modules needed by your package here

--- a/templates/buildPythonPackage/files/pkgs/default.nix
+++ b/templates/buildPythonPackage/files/pkgs/default.nix
@@ -1,11 +1,11 @@
 {
   self,
   python3Packages,
-  inputs,
+  lib,
 }:
 python3Packages.buildPythonPackage {
   pname = "my-package";
-  version = "0.0.0-${inputs.flox-floxpkgs.lib.getRev self}";
+  version = "0.0.0-${lib.flox-floxpkgs.getRev self}";
   src = self; # + "/src";
   PIP_DISABLE_PIP_VERSION_CHECK = 1;
   # Add Python modules needed by your package here

--- a/templates/buildRustPackage/files/pkgs/default.nix
+++ b/templates/buildRustPackage/files/pkgs/default.nix
@@ -8,10 +8,11 @@
   pkg-config,
   libiconv,
   darwin,
+  withRev
 }:
 rustPlatform.buildRustPackage rec {
   pname = "my-package";
-  version = "0.0.0";
+  version = withRev "0.0.0";
   src = self; # + "/src";
 
   cargoLock = {

--- a/templates/buildRustPackage/files/pkgs/default.nix
+++ b/templates/buildRustPackage/files/pkgs/default.nix
@@ -8,11 +8,11 @@
   pkg-config,
   libiconv,
   darwin,
-  withRev
+  inputs,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "my-package";
-  version = withRev "0.0.0";
+  version = "0.0.0-${inputs.flox-floxpkgs.lib.getRev self}";
   src = self; # + "/src";
 
   cargoLock = {

--- a/templates/buildRustPackage/files/pkgs/default.nix
+++ b/templates/buildRustPackage/files/pkgs/default.nix
@@ -8,11 +8,10 @@
   pkg-config,
   libiconv,
   darwin,
-  inputs,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "my-package";
-  version = "0.0.0-${inputs.flox-floxpkgs.lib.getRev self}";
+  version = "0.0.0-${lib.flox-floxpkgs.getRev self}";
   src = self; # + "/src";
 
   cargoLock = {

--- a/templates/mixRelease/files/pkgs/default.nix
+++ b/templates/mixRelease/files/pkgs/default.nix
@@ -3,7 +3,7 @@
   lib,
   beam,
   mix2nix,
-  getRev ? inputs.flox-floxpkgs.lib.getRev
+  inputs,
   ...
 }: let
   # You can specify the OTP version by appending R + version number to the "erlang" attribute,
@@ -14,7 +14,7 @@
 in
   beamPackages.mixRelease rec {
     pname = "my-package";
-    version = "0.0.0-${getRev self}";
+    version = "0.0.0-${inputs.flox-flxopkgs.lib.getRev self}";
     src = self; # + "/src";
 
     MIX_ENV = "prod";

--- a/templates/mixRelease/files/pkgs/default.nix
+++ b/templates/mixRelease/files/pkgs/default.nix
@@ -3,7 +3,6 @@
   lib,
   beam,
   mix2nix,
-  inputs,
   ...
 }: let
   # You can specify the OTP version by appending R + version number to the "erlang" attribute,
@@ -14,7 +13,7 @@
 in
   beamPackages.mixRelease rec {
     pname = "my-package";
-    version = "0.0.0-${inputs.flox-flxopkgs.lib.getRev self}";
+    version = "0.0.0-${lib.flox-flxopkgs.getRev self}";
     src = self; # + "/src";
 
     MIX_ENV = "prod";

--- a/templates/mixRelease/files/pkgs/default.nix
+++ b/templates/mixRelease/files/pkgs/default.nix
@@ -3,6 +3,7 @@
   lib,
   beam,
   mix2nix,
+  getRev ? inputs.flox-floxpkgs.lib.getRev
   ...
 }: let
   # You can specify the OTP version by appending R + version number to the "erlang" attribute,
@@ -13,7 +14,7 @@
 in
   beamPackages.mixRelease rec {
     pname = "my-package";
-    version = "0.0.0";
+    version = "0.0.0-${getRev self}";
     src = self; # + "/src";
 
     MIX_ENV = "prod";

--- a/templates/mkDerivation-java/files/pkgs/default.nix
+++ b/templates/mkDerivation-java/files/pkgs/default.nix
@@ -5,10 +5,11 @@
   jdk,
   ant,
   makeWrapper,
+  withRev
 }:
 stdenv.mkDerivation rec {
   pname = "my-package";
-  version = "0.0.0";
+  version = withRev "0.0.0";
   src = self; # + "/src";
   nativeBuildInputs = [ant jdk makeWrapper];
 

--- a/templates/mkDerivation-java/files/pkgs/default.nix
+++ b/templates/mkDerivation-java/files/pkgs/default.nix
@@ -4,11 +4,11 @@
   jdk,
   ant,
   makeWrapper,
-  inputs,
+  lib,
 }:
 stdenv.mkDerivation rec {
   pname = "my-package";
-  version = "0.0.0-${inputs.flox-flxopkgs.lib.getRev self}";
+  version = "0.0.0-${lib.flox-flxopkgs.getRev self}";
   src = self; # + "/src";
   nativeBuildInputs = [ant jdk makeWrapper];
 

--- a/templates/mkDerivation-java/files/pkgs/default.nix
+++ b/templates/mkDerivation-java/files/pkgs/default.nix
@@ -1,15 +1,14 @@
 {
   self,
-  lib,
   stdenv,
   jdk,
   ant,
   makeWrapper,
-  withRev
+  inputs,
 }:
 stdenv.mkDerivation rec {
   pname = "my-package";
-  version = withRev "0.0.0";
+  version = "0.0.0-${inputs.flox-flxopkgs.lib.getRev self}";
   src = self; # + "/src";
   nativeBuildInputs = [ant jdk makeWrapper];
 

--- a/templates/mkDerivation-ruby/files/pkgs/default.nix
+++ b/templates/mkDerivation-ruby/files/pkgs/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   bundlerEnv,
   ruby,
-  inputs,
+  lib,
 }: let
   # running the bundix command
   # will generate the gemset.nix file below
@@ -17,7 +17,7 @@
 in
   stdenv.mkDerivation rec {
     pname = "my-package";
-    version = "0.0.0-${inputs.flox-flxopkgs.lib.getRev self}";
+    version = "0.0.0-${lib.flox-flxopkgs.getRev self}";
     src = self; # + "/src";
     buildInputs = [gems ruby];
     installPhase = ''

--- a/templates/mkDerivation-ruby/files/pkgs/default.nix
+++ b/templates/mkDerivation-ruby/files/pkgs/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   bundlerEnv,
   ruby,
-  withRev
+  inputs,
 }: let
   # running the bundix command
   # will generate the gemset.nix file below
@@ -17,7 +17,7 @@
 in
   stdenv.mkDerivation rec {
     pname = "my-package";
-    version = withRev "0.0.0";
+    version = "0.0.0-${inputs.flox-flxopkgs.lib.getRev self}";
     src = self; # + "/src";
     buildInputs = [gems ruby];
     installPhase = ''

--- a/templates/mkDerivation-ruby/files/pkgs/default.nix
+++ b/templates/mkDerivation-ruby/files/pkgs/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   bundlerEnv,
   ruby,
+  withRev
 }: let
   # running the bundix command
   # will generate the gemset.nix file below
@@ -16,7 +17,7 @@
 in
   stdenv.mkDerivation rec {
     pname = "my-package";
-    version = "0.0.0";
+    version = withRev "0.0.0";
     src = self; # + "/src";
     buildInputs = [gems ruby];
     installPhase = ''

--- a/templates/mkDerivation/files/pkgs/default.nix
+++ b/templates/mkDerivation/files/pkgs/default.nix
@@ -2,12 +2,12 @@
 {
   self,
   stdenv,
-  inputs,
+  lib,
 }:
 # Replace "stdenv.mkDerivation" with your language's builder
 stdenv.mkDerivation {
   pname = "my-package";
-  version = "0.0.0-${inputs.flox-floxpkgs.lib.getRev self}";
+  version = "0.0.0-${lib.flox-flxopkgs.getRev self}";
   src = self; # + "/src";
 
   # Add runtime dependencies to buildInputs.

--- a/templates/mkDerivation/files/pkgs/default.nix
+++ b/templates/mkDerivation/files/pkgs/default.nix
@@ -1,9 +1,13 @@
 # Replace "stdenv" with the namespace or name of your language's builder
-{ self, stdenv, withRev }:
+{
+  self,
+  stdenv,
+  inputs,
+}:
 # Replace "stdenv.mkDerivation" with your language's builder
 stdenv.mkDerivation {
   pname = "my-package";
-  version = withRev "0.0.0";
+  version = "0.0.0-${inputs.flox-floxpkgs.lib.getRev self}";
   src = self; # + "/src";
 
   # Add runtime dependencies to buildInputs.

--- a/templates/mkDerivation/files/pkgs/default.nix
+++ b/templates/mkDerivation/files/pkgs/default.nix
@@ -1,9 +1,9 @@
 # Replace "stdenv" with the namespace or name of your language's builder
-{ self, stdenv }:
+{ self, stdenv, withRev }:
 # Replace "stdenv.mkDerivation" with your language's builder
 stdenv.mkDerivation {
   pname = "my-package";
-  version = "0.0.0";
+  version = withRev "0.0.0";
   src = self; # + "/src";
 
   # Add runtime dependencies to buildInputs.

--- a/templates/mkYarnPackage/files/pkgs/default.nix
+++ b/templates/mkYarnPackage/files/pkgs/default.nix
@@ -1,6 +1,10 @@
-{self, mkYarnPackage, withRev}: let
+{
+  self,
+  mkYarnPackage,
+  inputs,
+}: let
   pname = "my-package";
-  version = withRev "0.0.0";
+  version = "0.0.0-${inputs.flox-flxopkgs.lib.getRev self}";
   src = self; # + "/src";
 in
   mkYarnPackage {

--- a/templates/mkYarnPackage/files/pkgs/default.nix
+++ b/templates/mkYarnPackage/files/pkgs/default.nix
@@ -1,11 +1,11 @@
 {
   self,
   mkYarnPackage,
-  inputs,
+  lib,
 }: let
   pname = "my-package";
-  version = "0.0.0-${inputs.flox-flxopkgs.lib.getRev self}";
-  src = self; # + "/src";
+  version = "0.0.0-${lib.flox-flxopkgs.getRev self}";
+  src = self;
 in
   mkYarnPackage {
     inherit pname version src;

--- a/templates/mkYarnPackage/files/pkgs/default.nix
+++ b/templates/mkYarnPackage/files/pkgs/default.nix
@@ -1,6 +1,6 @@
-{self, mkYarnPackage}: let
+{self, mkYarnPackage, withRev}: let
   pname = "my-package";
-  version = "0.0.0";
+  version = withRev "0.0.0";
   src = self; # + "/src";
 in
   mkYarnPackage {


### PR DESCRIPTION
The `withRev` function will append a "-rXXX" string to the version string to provide automatic tracking of version increments in package versions. Adding this to all templates by default.