### PR TITLE
ci:  do not update lockfile on push to `catalog` folder

### DIFF
--- a/.github/workflows/trigger-update.yml
+++ b/.github/workflows/trigger-update.yml
@@ -2,6 +2,8 @@ name: "Trigger Update of floxpkgs/index"
 
 on:
   push:
+     paths-ignore:
+      - '/catalog/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
With automated publishes, the update lockfile action is triggered four times (once for each system) in response to every update of the catalog.

Since nothing locked changes due to a push of a catalog entry, we should ignore these events