### PR TITLE
fix relative path for deps.nix

### DIFF
--- a/templates/mixRelease/files/pkgs/default.nix
+++ b/templates/mixRelease/files/pkgs/default.nix
@@ -21,7 +21,7 @@ in
     buildInputs = [ mix2nix elixir ];
 
     # At the root of your project directory, run "mix2nix > deps.nix" to create this file.
-    mixNixDeps = import ./../deps.nix { inherit lib beamPackages; };
+    mixNixDeps = import ./../../deps.nix { inherit lib beamPackages; };
 
     # for phoenix framework you can uncomment the lines below
     # for external task you need a workaround for the no deps check flag


### PR DESCRIPTION
the default.nix file is nested two folders down, not one.