### PR TITLE
feat(floxEnvs): support hooks, aliases, and env vars

### DIFF
--- a/lib/mkFloxEnv.nix
+++ b/lib/mkFloxEnv.nix
@@ -16,7 +16,9 @@
           inherit system self;
         };
       }
-      (self + "/modules/flox-env.nix")
+      (self + "/modules/common.nix")
+      (self + "/modules/options.nix")
+      (self + "/modules/shells/posix.nix")
     ]
     ++ modules;
 })

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -24,10 +24,6 @@
       type = types.path;
     };
 
-    toplevel = mkOption {
-      type = types.package;
-    };
-
     manifestPath = mkOption {
       internal = true;
       type = types.path;
@@ -158,17 +154,7 @@
     system.path = pkgs.buildEnv {
       name = "system-path";
       paths = config.environment.systemPackages;
-      ignoreCollisions = true;
-    };
-
-    toplevel = pkgs.stdenvNoCC.mkDerivation {
-      name = "floxEnv";
-      buildCommand = ''
-        mkdir $out
-        ln -s ${config.system.path} $out/sw
-        ln -s ${config.newCatalogPath} $out/catalog.json
-        touch $out/activate
-      '';
+      ignoreCollisions = false;
     };
   };
 }

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -1,0 +1,31 @@
+# options that all runners (e.g. bash, eventually containers) should use
+{
+  config,
+  lib,
+  ...
+}:
+with lib; {
+  options = {
+    variables = mkOption {
+      default = {};
+      example = {
+        EDITOR = "nvim";
+        VISUAL = "nvim";
+      };
+      description = lib.mdDoc ''
+        A set of environment variables. The value of each variable can be either a string or a list of
+        strings.  The latter is concatenated, interspersed with colon
+        characters.
+      '';
+      type = with types; attrsOf (either str (listOf str));
+      apply = mapAttrs (n: v:
+        if isList v
+        then concatStringsSep ":" v
+        else v);
+    };
+
+    toplevel = mkOption {
+      type = types.package;
+    };
+  };
+}

--- a/modules/shells/posix.nix
+++ b/modules/shells/posix.nix
@@ -1,0 +1,67 @@
+# options and implementation for all POSIX shells
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; {
+  # common options for POSIX compatible shells
+  options = {
+    shell = {
+      aliases = mkOption {
+        example = {
+          ll = "ls -l";
+        };
+        description = lib.mdDoc ''
+          An attribute set that maps aliases (the top level attribute names in
+          this option) to command strings or directly to packages.
+          Aliases mapped to `null` are ignored.
+        '';
+        type = with types; attrsOf (nullOr (either str path));
+      };
+      hook = mkOption {
+        default = "";
+        description = lib.mdDoc ''
+          Shell script code called during environment activation.
+          This code is assumed to be shell-independent, which means you should
+          stick to pure sh without sh word split.
+        '';
+        type = types.lines;
+      };
+    };
+  };
+
+  config = let
+    stringAliases = concatStringsSep "\n" (
+      mapAttrsFlatten (k: v: "alias ${k}=${escapeShellArg v}")
+      (filterAttrs (k: v: v != null) config.shell.aliases)
+    );
+
+    exportedEnvVars = let
+      # make foo = "bar" -> foo = ["bar"]
+      allValuesLists =
+        mapAttrs (n: toList) config.variables;
+      exportVariables =
+        mapAttrsToList (n: v: ''export ${n}="${concatStringsSep ":" v}"'') allValuesLists;
+    in
+      concatStringsSep "\n" exportVariables;
+    activateScript = builtins.toFile "activate" ''
+      ${exportedEnvVars}
+
+      ${stringAliases}
+
+      ${config.shell.hook}
+    '';
+  in {
+    toplevel = pkgs.stdenvNoCC.mkDerivation {
+      name = "floxEnv";
+      buildCommand = ''
+        mkdir $out
+        ln -s ${config.system.path} $out/sw
+        ln -s ${config.newCatalogPath} $out/catalog.json
+        ln -s ${activateScript} $out/activate
+      '';
+    };
+  };
+}


### PR DESCRIPTION
floxEnvs will have to support multiple runners (e.g. shells and containers), so shell specific options are kept separate from common options.

Much of this implementation is copied from nixpkgs