### PR TITLE
refactor: comment mixNixDeps by default

### DIFF
--- a/templates/mixRelease/files/pkgs/default.nix
+++ b/templates/mixRelease/files/pkgs/default.nix
@@ -20,8 +20,9 @@ in
 
     buildInputs = [ mix2nix elixir ];
 
-    # At the root of your project directory, run "mix2nix > deps.nix" to create this file.
-    mixNixDeps = import ./../../deps.nix { inherit lib beamPackages; };
+    # At the root of your project directory, run "mix2nix > deps.nix" to create the deps.nix file.
+    # Then, uncomment the mixNixDeps line below.
+    #mixNixDeps = import ./../../deps.nix { inherit lib beamPackages; };
 
     # for phoenix framework you can uncomment the lines below
     # for external task you need a workaround for the no deps check flag


### PR DESCRIPTION
If we comment out `mixNixDeps` to start out with, the user can run `flox develop` which will bring `mix2nix` into scope, and will allow the user to run it, and then they can uncomment the mixNixDeps line and build the package