### PR TITLE
templates/_init/flake.nix: rename flox/floxpkgs input

### DIFF
--- a/templates/_init/flake.nix
+++ b/templates/_init/flake.nix
@@ -1,12 +1,12 @@
 {
   description = "Floxpkgs/Project Template";
   nixConfig.bash-prompt = "[flox] \\[\\033[38;5;172m\\]λ \\[\\033[0m\\]";
-  inputs.floxpkgs.url = "github:flox/floxpkgs";
+  inputs.flox-floxpkgs.url = "github:flox/floxpkgs";
 
   # Declaration of external resources
   # =================================
 
   # =================================
 
-  outputs = args @ {floxpkgs, ...}: floxpkgs.project args (_: {});
+  outputs = args @ {flox-floxpkgs, ...}: flox-floxpkgs.project args (_: {});
 }


### PR DESCRIPTION
Disambiguate the various floxpkgs inputs by naming them according to their full "organization/project" paths, replacing "/" with "-".