### PR TITLE
fix!: require passing pkgs to lib.mkEnv

### DIFF
--- a/lib/mkEnv.nix
+++ b/lib/mkEnv.nix
@@ -1,14 +1,20 @@
 # Capacitor API
 {
- lib,
- self,
- buildEnv,
- writeTextDir,
- system,
- coreutils,
- bashInteractive,
- writeTextFile,
+  lib,
+  self,
+}: args @ {
+  name ? "floxShell",
+  # A path to a buildEnv that will be loaded by the shell.
+  # We assume that the buildEnv contains an ./env.bash script.
+  packages ? [],
+  meta ? {},
+  passthru ? {},
+  env ? {},
+  manifestPath,
+  pkgs,
+  ...
 }:
+# TODO: let packages' = if builtins.isList builtins.isSet
 let
   bashPath = "${bashInteractive}/bin/bash";
   stdenv = writeTextFile {
@@ -23,88 +29,90 @@ let
       }
     '';
   };
-in
-args@{ name ? "floxShell"
-  # A path to a buildEnv that will be loaded by the shell.
-  # We assume that the buildEnv contains an ./env.bash script.
-, packages ? [ ]
-, meta ? { }
-, passthru ? { }
-, env ? {}
-, manifestPath
-, ...
-}:
-# TODO: let packages' = if builtins.isList builtins.isSet
-let rest = builtins.removeAttrs args [
-  "name"
-  "profile"
-  "packages"
-  "meta"
-  "passthru"
-  "env"
-  "manifestPath"
-];
+  inherit
+    (pkgs)
+    buildEnv
+    writeTextDir
+    system
+    coreutils
+    bashInteractive
+    writeTextFile
+    ;
+  rest = builtins.removeAttrs args [
+    "name"
+    "profile"
+    "packages"
+    "meta"
+    "passthru"
+    "env"
+    "manifestPath"
+    "pkgs"
+  ];
   envToBash = name: value: "export ${name}=${lib.escapeShellArg (toString value)}";
   envBash = writeTextDir "env.bash" ''
     export PATH="@DEVSHELL_DIR@/bin:$PATH"
     ${builtins.concatStringsSep "\n" (builtins.attrValues (builtins.mapAttrs envToBash (args.env or {})))}
     ${args.postShellHook or ""}
   '';
-  profile =
-     let
-       env = derivation {
-          name = "profile";
-          builder = "builtin:buildenv";
-          inherit system;
-          manifest = "/dummy";
-          derivations = map (x: ["true" 5 1 x]) args.packages;
-        };
-       manifest = derivation {
-          name = "profile";
-          inherit system;
-          builder = "/bin/sh";
-          args = ["-c" "echo ${env}; ${coreutils}/bin/mkdir $out; ${coreutils}/bin/cp ${manifestPath} $out/manifest.json"];
-        };
-    in
-        buildEnv ({
-          name = "wrapper";
-          paths = args.packages ++ [manifest envBash];
+  profile = let
+    env = derivation {
+      name = "profile";
+      builder = "builtin:buildenv";
+      inherit system;
+      manifest = "/dummy";
+      derivations = map (x: ["true" 5 1 x]) args.packages;
+    };
+    manifest = derivation {
+      name = "profile";
+      inherit system;
+      builder = "/bin/sh";
+      args = ["-c" "echo ${env}; ${coreutils}/bin/mkdir $out; ${coreutils}/bin/cp ${manifestPath} $out/manifest.json"];
+    };
+  in
+    buildEnv ({
+        name = "wrapper";
+        paths = args.packages ++ [manifest envBash];
 
-          postBuild = ''
-            rm $out/env.bash ; substitute ${envBash}/env.bash $out/env.bash --subst-var-by DEVSHELL_DIR $out
-            ${args.postBuild or ""}
-          '';
-        } // (builtins.removeAttrs rest ["postShellHook" "shellHook" "preShellHook" "postBuild"]));
+        postBuild = ''
+          rm $out/env.bash ; substitute ${envBash}/env.bash $out/env.bash --subst-var-by DEVSHELL_DIR $out
+          ${args.postBuild or ""}
+        '';
+      }
+      // (builtins.removeAttrs rest ["postShellHook" "shellHook" "preShellHook" "postBuild"]));
 in
-(derivation ({
-  inherit name system;
-  outputs = [ "out" ];
+  (derivation ({
+      inherit name system;
+      outputs = ["out"];
 
-  # `nix develop` actually checks and uses builder. And it must be bash.
-  builder = bashPath;
+      # `nix develop` actually checks and uses builder. And it must be bash.
+      builder = bashPath;
 
-  # Bring in the dependencies on `nix-build`
-  args = [ "-ec" "${coreutils}/bin/ln -s ${profile} $out; exit 0" ];
+      # Bring in the dependencies on `nix-build`
+      args = ["-ec" "${coreutils}/bin/ln -s ${profile} $out; exit 0"];
 
-  # $stdenv/setup is loaded by nix-shell during startup.
-  # https://github.com/nixos/nix/blob/377345e26f1ac4bbc87bb21debcc52a1d03230aa/src/nix-build/nix-build.cc#L429-L432
-  stdenv = stdenv;
+      # $stdenv/setup is loaded by nix-shell during startup.
+      # https://github.com/nixos/nix/blob/377345e26f1ac4bbc87bb21debcc52a1d03230aa/src/nix-build/nix-build.cc#L429-L432
+      stdenv = stdenv;
 
-  # The shellHook is loaded directly by `nix develop`. But nix-shell
-  # requires that other trampoline.
-  shellHook = ''
-    # Remove all the unnecessary noise that is set by the build env
-    unset NIX_BUILD_TOP NIX_BUILD_CORES NIX_STORE
-    unset TEMP TEMPDIR TMP TMPDIR
-    # $name variable is preserved to keep it compatible with pure shell https://github.com/sindresorhus/pure/blob/47c0c881f0e7cfdb5eaccd335f52ad17b897c060/pure.zsh#L235
-    unset builder out shellHook stdenv system
-    # Flakes stuff
-    unset dontAddDisableDepTrack outputs
-    # For `nix develop`. We get /noshell on Linux and /sbin/nologin on macOS.
-    if [[ "$SHELL" == "/noshell" || "$SHELL" == "/sbin/nologin" ]]; then
-      export SHELL=${bashPath}
-    fi
-    # Load the environment
-    source "${profile}/activate"
-  '';
-} // rest // (args.env or {}))) // { inherit meta passthru; } // passthru
+      # The shellHook is loaded directly by `nix develop`. But nix-shell
+      # requires that other trampoline.
+      shellHook = ''
+        # Remove all the unnecessary noise that is set by the build env
+        unset NIX_BUILD_TOP NIX_BUILD_CORES NIX_STORE
+        unset TEMP TEMPDIR TMP TMPDIR
+        # $name variable is preserved to keep it compatible with pure shell https://github.com/sindresorhus/pure/blob/47c0c881f0e7cfdb5eaccd335f52ad17b897c060/pure.zsh#L235
+        unset builder out shellHook stdenv system
+        # Flakes stuff
+        unset dontAddDisableDepTrack outputs
+        # For `nix develop`. We get /noshell on Linux and /sbin/nologin on macOS.
+        if [[ "$SHELL" == "/noshell" || "$SHELL" == "/sbin/nologin" ]]; then
+          export SHELL=${bashPath}
+        fi
+        # Load the environment
+        source "${profile}/activate"
+      '';
+    }
+    // rest
+    // (args.env or {})))
+  // {inherit meta passthru;}
+  // passthru

--- a/modules/shells/posix.nix
+++ b/modules/shells/posix.nix
@@ -3,6 +3,7 @@
   config,
   lib,
   pkgs,
+  self,
   ...
 }:
 with lib; {
@@ -60,7 +61,8 @@ with lib; {
       '';
     };
   in {
-    toplevel = pkgs.callPackage ../../lib/mkEnv.nix {} {
+    toplevel = self.lib.mkEnv {
+      inherit pkgs;
       packages = config.environment.systemPackages ++ [config.newCatalogPath activateScript];
       manifestPath = config.manifestPath;
     };


### PR DESCRIPTION
The main purpose is to make lib.mkEnv available. The distinction between how this is done with mkFloxEnv is where the packages come from. This is a constant problem with lib functions that are system or pkgs-dependent. Not sure which style is best.