### PR TITLE
feat: inject default nixpkgs

### DIFF
--- a/flox.nix
+++ b/flox.nix
@@ -44,7 +44,7 @@
   ];
 
   passthru.project = args: config:
-    inputs.capacitor args (
+    inputs.capacitor ({ nixpkgs = inputs.nixpkgs; } // args) (
       context:
         lib.recursiveUpdate {
           config.plugins = inputs.capacitor.defaultPlugins ++ self.defaultPlugins;


### PR DESCRIPTION
Flakes built with floxpkgs.project should use the nixpkgs from floxpkgs, which is modified by flox' stability flags