### PR TITLE
don't add floxEnvs to devShells

### DIFF
--- a/plugins/floxEnvs.nix
+++ b/plugins/floxEnvs.nix
@@ -37,8 +37,6 @@ in
       };
       path = [system] ++ namespace;
     };
-    result = materialize (floxEnvsMapper context) (context.closures sourceType);
   in {
-    floxEnvs = result;
-    devShells = result;
+    floxEnvs = materialize (floxEnvsMapper context) (context.closures sourceType);
   }


### PR DESCRIPTION
We've decided the CLI will handle activation of floxEnvs, so floxEnvs should not be put in devShells. If added to devShells, the normal behavior of nix develop to use packages.*.* will be shadowed