### PR TITLE
unfree packages, fix self, use fetchClosure

### DIFF
--- a/lib/mkFakeDerivation.nix
+++ b/lib/mkFakeDerivation.nix
@@ -47,10 +47,13 @@
           then
             if builtins.any (cacheMetadata: cacheMetadata.state == "hit") element.cache
             then
-              builtins.fetchClosure {
-                fromStore = (builtins.head element.cache).cacheUrl;
-                fromPath = outputs.${outputName};
-              }
+              if builtins ? fetchClosure
+              then
+                builtins.fetchClosure {
+                  fromStore = (builtins.head element.cache).cacheUrl;
+                  fromPath = outputs.${outputName};
+                }
+              else builtins.storePath outputs.${outputName}
             else fromSource.${outputName}
           else fromSource.${outputName};
       };

--- a/lib/mkFakeDerivation.nix
+++ b/lib/mkFakeDerivation.nix
@@ -1,11 +1,84 @@
 # mkFakeDerivation transforms data in catalog format into a fake derivation with a store path that
 # can be substituted
 {lib}: element: let
-  outputs = element.eval.outputs or (throw "unable to create mkFakeDerivation: no eval.outputs");
   fromSource = with element.element;
     if url == ""
     then throw "url = \"\" so this fakeDerivation can't be built from source. Note that fakeDerivations created from self cannot be built from source"
     else lib.getAttrFromPath attrPath (builtins.getFlake url);
+
+  # We could be
+  # 1. using an entry from the catalog that has a cache hit
+  # 2. using an entry from the catalog that does not have a cache hit and is
+  #   a. built locally
+  #   b. not built locally
+  # We shouldn't ever have an entry from self - fakeDerivations shouldn't be created with
+  # self entries, since they've already been realized, but they don't have a cache entry
+  #
+  # For case 2a, it would be preferable if we could try builtins.storePath, but we can't, so
+  # just build from source
+  getOutPath = outputName: let
+    stringOutPath = outputs.${outputName};
+    cacheUrl =
+      if element ? cache
+      then
+        if builtins.isList element.cache
+        # builtfilter style cache entry
+        # cache = [
+        #   {
+        #     cacheUrl = "https://cache.floxdev.com";
+        #     narinfo = [
+        #       {
+        #         path = "/nix/store/XXX";
+        #         ...
+        #       }
+        #     ];
+        #   }
+        # ];
+        then
+          builtins.foldl' (
+            cacheUrl: cacheMetadata:
+              if cacheUrl != null
+              then cacheUrl
+              else if builtins.any (narinfo: narinfo.path == stringOutPath) cacheMetadata
+              then cacheMetadata.cacheUrl
+              else null
+          )
+          null
+          element.cache
+        # update-catalog style cache entry
+        # cache = {
+        #   out = {
+        #     "https://cache.nixos.org" = {
+        #       # only present for invalid entries
+        #       valid = false;
+        #     };
+        #   };
+        # };
+        else if element.cache ? ${outputName}
+        then
+          builtins.foldl' (foundCacheUrl: cacheUrl:
+            if foundCacheUrl != null
+            then foundCacheUrl
+            else if element.cache.${outputName}.${cacheUrl}.valid or null == "false"
+            then null
+            # absence of valid means an entry is valid
+            else cacheUrl)
+          null (builtins.attrNames element.cache.${outputName})
+        else null
+      else null;
+  in
+    if cacheUrl != null
+    then
+      if builtins ? fetchClosure
+      then
+        builtins.fetchClosure {
+          fromStore = cacheUrl;
+          fromPath = stringOutPath;
+        }
+      else builtins.storePath stringOutPath
+    else fromSource.${outputName};
+
+  outputs = element.eval.outputs or (throw "unable to create mkFakeDerivation: no eval.outputs");
   outputNames = builtins.attrNames outputs;
   defaultOutput = builtins.head outputNames;
   common =
@@ -34,79 +107,7 @@
       common
       // rec {
         inherit outputName;
-        outPath =
-          # We could be
-          # 1. using an entry from the catalog that has a cache hit
-          # 2. using an entry from the catalog that does not have a cache hit and is
-          #   a. built locally
-          #   b. not built locally
-          # We shouldn't ever have an entry from self - fakeDerivations shouldn't be created with
-          # self entries, since they've already been realized, but they don't have a cache entry
-          #
-          # For case 2a, it would be preferable if we could try builtins.storePath, but we can't, so
-          # just build from source
-          let
-            cacheUrl = let
-              stringOutPath = outputs.${outputName};
-            in
-              if element ? cache
-              then
-                if builtins.isList element.cache
-                # builtfilter style cache entry
-                # cache = [
-                #   {
-                #     cacheUrl = "https://cache.floxdev.com";
-                #     narinfo = [
-                #       {
-                #         path = "/nix/store/XXX";
-                #         ...
-                #       }
-                #     ];
-                #   }
-                # ];
-                then
-                  builtins.foldl' (
-                    cacheUrl: cacheMetadata:
-                      if cacheUrl != null
-                      then cacheUrl
-                      else if builtins.any (narinfo: narinfo.path == stringOutPath) cacheMetadata
-                      then cacheMetadata.cacheUrl
-                      else null
-                  )
-                  null
-                  element.cache
-                # update-catalog style cache entry
-                # cache = {
-                #   out = {
-                #     "https://cache.nixos.org" = {
-                #       # only present for invalid entries
-                #       valid = false;
-                #     };
-                #   };
-                # };
-                else if element.cache ? ${outputName}
-                then
-                  builtins.foldl' (foundCacheUrl: cacheUrl:
-                    if foundCacheUrl != null
-                    then foundCacheUrl
-                    else if element.cache.${outputName}.${cacheUrl}.valid or null == "false"
-                    then null
-                    # absence of valid means an entry is valid
-                    else cacheUrl)
-                  null (builtins.attrNames element.cache.${outputName})
-                else null
-              else null;
-          in
-            if cacheUrl != null
-            then
-              if builtins ? fetchClosure
-              then
-                builtins.fetchClosure {
-                  fromStore = cacheUrl;
-                  fromPath = stringOutPath;
-                }
-              else builtins.storePath stringOutPath
-            else fromSource.${outputName};
+        outPath = getOutPath outputName;
       };
   };
   outputsList = map outputToAttrListElement outputNames;


### PR DESCRIPTION
- Unfree packages do not have a cache entry and must be built from source
- Currently self package are wrapped in a fakeDerivation that can't be built from source, so instead just passthrough the actual derivation
- Use fetchClosure now that we have a value for fromStore