### PR TITLE
feat: add floxEnv container and module options

### DIFF
--- a/lib/mkContainer.nix
+++ b/lib/mkContainer.nix
@@ -31,5 +31,9 @@ in
           then ["${pkgs.bashInteractive}/bin/bash" "--rcfile" "${drv}/activate"]
           else buildLayeredImageArgs.config.entrypoint;
       };
-      contents = [drv] ++ lib.optionals runFloxActivate (with pkgs; [bashInteractive coreutils]);
+      # symlinkJoin fails when drv contains a symlinked bin directory, so wrap in an additional buildEnv
+      contents = pkgs.buildEnv {
+        name = "contents";
+        paths = [drv] ++ lib.optionals runFloxActivate (with pkgs; [bashInteractive coreutils]);
+      };
     })

--- a/lib/mkContainer.nix
+++ b/lib/mkContainer.nix
@@ -1,0 +1,35 @@
+# at this point just a thin wrapper around streamLayeredImage, but still worth
+# having to keep as much functionality as possible in lib rather than the module
+# system
+{
+  inputs,
+  lib,
+}: {
+  context,
+  system,
+  drv,
+  entrypoint ? null,
+  buildLayeredImageArgs,
+}: let
+  pkgs = context.nixpkgs.legacyPackages.${system};
+  name = buildLayeredImageArgs.name;
+  builderArgsHaveEntrypoint = buildLayeredImageArgs ? config.entrypoint && buildLayeredImageArgs.config.entrypoint != null;
+  runFloxActivate = entrypoint == null && !builderArgsHaveEntrypoint;
+in
+  pkgs.dockerTools.streamLayeredImage (lib.recursiveUpdate buildLayeredImageArgs
+    {
+      config = {
+        entrypoint =
+          if
+            entrypoint
+            != null
+          then
+            if builderArgsHaveEntrypoint
+            then throw "cannot specify both entrypoint and config.entrypoint"
+            else entrypoint
+          else if runFloxActivate
+          then ["${pkgs.bashInteractive}/bin/bash" "--rcfile" "${drv}/activate"]
+          else buildLayeredImageArgs.config.entrypoint;
+      };
+      contents = [drv] ++ lib.optionals runFloxActivate (with pkgs; [bashInteractive coreutils]);
+    })

--- a/lib/mkFloxEnv.nix
+++ b/lib/mkFloxEnv.nix
@@ -2,18 +2,18 @@
   lib,
   nixpkgs,
   self,
-  #  system,
 }: {
-  system,
-  modules,
   context,
+  namespace,
+  modules,
+  system,
 }:
 (lib.evalModules {
   modules =
     [
       {
         _module.args = {
-          inherit system context;
+          inherit context namespace system;
         };
       }
       (self + "/modules/common.nix")

--- a/lib/mkFloxEnv.nix
+++ b/lib/mkFloxEnv.nix
@@ -18,6 +18,7 @@
       }
       (self + "/modules/common.nix")
       (self + "/modules/options.nix")
+      (self + "/modules/container.nix")
       (self + "/modules/shells/posix.nix")
     ]
     ++ modules;

--- a/modules/container.nix
+++ b/modules/container.nix
@@ -1,0 +1,131 @@
+{
+  context,
+  system,
+  config,
+  lib,
+  ...
+}: let
+  floxpkgs = context.inputs.flox-floxpkgs;
+in {
+  options.container = with lib; {
+    name = mkOption {
+      description = mdDoc ''The name of the resulting image.'';
+      type = types.str;
+      default = "floxEnv";
+    };
+
+    tag = mkOption {
+      description = lib.mdDoc ''Tag of the generated image.'';
+      type = types.str;
+      default = "latest";
+    };
+
+    # fromImage = mkOption {
+    #   description = lib.mdDoc ''The repository tarball containing the base image. It must be a valid Docker image, such as one exported by `docker save`.'';
+    #   default = null;
+    # };
+
+    # contents = mkOption {
+    #   description = lib.mdDoc ''Top-level paths in the container. Either a single derivation, or a list of derivations.'';
+    #   default = [];
+    # };
+
+    # architecture = mkOption {
+    #   description =
+    #     lib.mdDoc ''
+    #       used to specify the image architecture, this is useful for multi-architecture builds that don't need cross compiling. If not specified it will default to `hostPlatform`.'';
+    #   default = {};
+    # };
+
+    config = mkOption {
+      description = lib.mdDoc ''
+        Run-time configuration of the container. A full list of the options
+        are available at in the
+        [Docker Image Specification v1.2.0](https://github.com/moby/moby/blob/master/image/spec/v1.2.md#image-json-field-descriptions).
+        Note that config.env is not supported (use environmentVariables instead)
+      '';
+      type = types.anything;
+      default = {};
+    };
+
+    created = mkOption {
+      description = lib.mdDoc ''Date and time the layers were created.'';
+      type = types.str;
+      default = "now";
+    };
+
+    maxLayers = mkOption {
+      description = lib.mdDoc ''Maximum number of layers to create. At most 125'';
+      type = types.int;
+      default = 100;
+    };
+
+    extraCommands = mkOption {
+      description = lib.mdDoc ''
+        Shell commands to run while building the final layer, without access to
+        most of the layer contents. Changes to this layer are "on top" of all
+        the other layers, so can create additional directories and files.
+      '';
+      type = types.lines;
+      default = "";
+    };
+
+    # fakeRootCommands = mkOption {
+    #   description = lib.mdDoc ''
+    #     Shell commands to run while creating the archive for the final layer in
+    #     a fakeroot environment. Unlike `extraCommands`, you can run `chown` to
+    #     change the owners of the files in the archive, changing fakeroot's state
+    #     instead of the real filesystem. The latter would require privileges that
+    #     the build user does not have. Static binaries do not interact with the
+    #     fakeroot environment. By default all files in the archive will be owned
+    #     by root.
+    #   '';
+    #   default = null;
+    # };
+
+    # enableFakechroot = mkOption {
+    #   description = lib.mdDoc ''
+    #     Whether to run in `fakeRootCommands` in `fakechroot`, making programs
+    #     behave as though `/` is the root of the image being created, while files
+    #     in the Nix store are available as usual. This allows scripts that
+    #     perform installation in `/` to work as expected. Considering that
+    #     `fakechroot` is implemented via the same mechanism as `fakeroot`, the
+    #     same caveats apply.
+    #   '';
+    #   default = false;
+    # };
+
+    entrypoint = mkOption {
+      description = lib.mdDoc ''
+        A command and its arguments to run when starting a container.
+      '';
+      type = types.nullOr (types.listOf types.str);
+      default = null;
+    };
+  };
+  config = {
+    passthru.streamLayeredImage = let
+      environmentVariables =
+        if builtins.isList config.environmentVariables && config.container.entrypoint != null
+        then throw "ordered environment variables are not supported in containers when entrypoint is specified"
+        else (lib.mapAttrsToList (n: v: ''${n}=${v}'') config.environmentVariables);
+    in
+      floxpkgs.lib.mkContainer {
+        inherit context system;
+        drv = config.passthru.posix;
+        buildLayeredImageArgs =
+          lib.recursiveUpdate
+          (builtins.removeAttrs config.container ["entrypoint"])
+          {
+            config.env =
+              if (config.container.entrypoint != null)
+              then environmentVariables
+              # The default entrypoint (flox activation) will pull in
+              # environmentVariables, and discard config.env for consistency
+              # even if there is a different entrypoint
+              else [];
+          };
+        entrypoint = config.container.entrypoint;
+      };
+  };
+}

--- a/modules/container.nix
+++ b/modules/container.nix
@@ -1,5 +1,6 @@
 {
   context,
+  namespace,
   system,
   config,
   lib,
@@ -11,7 +12,7 @@ in {
     name = mkOption {
       description = mdDoc ''The name of the resulting image.'';
       type = types.str;
-      default = "floxEnv";
+      default = builtins.elemAt namespace (builtins.length namespace - 1);
     };
 
     tag = mkOption {

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -51,7 +51,7 @@ with lib; {
       description = lib.mdDoc ''
         Packages to expose under toplevel.passthru
       '';
-      type = types.attrsOf types.package;
+      type = types.attrs;
       internal = true;
     };
   };

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -47,5 +47,12 @@ with lib; {
     toplevel = mkOption {
       type = types.package;
     };
+    passthru = mkOption {
+      description = lib.mdDoc ''
+        Packages to expose under toplevel.passthru
+      '';
+      type = types.attrsOf types.package;
+      internal = true;
+    };
   };
 }

--- a/modules/shells/posix.nix
+++ b/modules/shells/posix.nix
@@ -70,10 +70,11 @@ in
         '';
       };
     in {
-      toplevel = floxpkgs.lib.mkEnv {
+      passthru.posix = floxpkgs.lib.mkEnv {
         inherit pkgs;
         packages = config.environment.systemPackages ++ [config.newCatalogPath activateScript];
         manifestPath = config.manifestPath;
       };
+      toplevel = config.passthru.posix // {passthru = config.passthru;} // config.passthru;
     };
   }

--- a/modules/shells/posix.nix
+++ b/modules/shells/posix.nix
@@ -74,6 +74,7 @@ in
         inherit pkgs;
         packages = config.environment.systemPackages ++ [config.newCatalogPath activateScript];
         manifestPath = config.manifestPath;
+        meta.buildLayeredImageArgs = config.passthru.buildLayeredImageArgs;
       };
       toplevel = config.passthru.posix // {passthru = config.passthru;} // config.passthru;
     };

--- a/plugins/floxEnvs.nix
+++ b/plugins/floxEnvs.nix
@@ -32,7 +32,7 @@ in
       # for now just treat flox.nix as a module, although at some point we might want to do something like
       # context.auto.callPackageWith injectedArgs floxNixPath {};
       value = self.lib.mkFloxEnv {
-        inherit context system;
+        inherit context system namespace;
         modules = [floxNixPath] ++ lib.optional (builtins.pathExists catalogPath) {inherit catalogPath;};
       };
       path = [system] ++ namespace;


### PR DESCRIPTION
If no entrypoint is specified, a floxEnv container starts by performing
(bash) activation. Otherwise, shell module options are ignored, and the
entrypoint is run in a container with the appropriate paths and env vars