### PR TITLE
fix(modules): always use the same version of mkFakeDerivation

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -281,13 +281,13 @@ in {
                 } {analyzeOutput = true;}
                 maybeFakeDerivation;
 
-            fakeDerivation =
-              if maybeFakeDerivation ? meta.element
-              then maybeFakeDerivation
-              # we have to wrap derivations from flakes in a fake derivation, because that's what
-              # will happen once they are put in the catalog. And the floxEnv must be identical for
-              # the locking and locked build
-              else floxpkgs.lib.mkFakeDerivation catalogData;
+            # The floxEnv must be identical for the locking and locked build, so we have to
+            # - call mkFakeDerivation even if we already have a fake derivation, because the version
+            #   of mkFakeDerivation used by the catalog plugin may be different than the version
+            #   called in this file
+            # - wrap derivations from flakes in a fake derivation, because that's what
+            #   will happen once they are put in the catalog
+            fakeDerivation = floxpkgs.lib.mkFakeDerivation catalogData;
           in
             # this function returns just the entries for this channel, and the caller adds channelName to the complete catalog
             rec {


### PR DESCRIPTION
The floxEnv must be identical for the locking and locked build, so we have to call mkFakeDerivation even if we already have a fake derivation, because the version of mkFakeDerivation used by the catalog plugin may be different than the version called by the floxEnv modules