### PR TITLE
fix: pass all publishData to mkFakeDerivation

### DIFF
--- a/lib/mkFakeDerivation.nix
+++ b/lib/mkFakeDerivation.nix
@@ -1,7 +1,15 @@
 # mkFakeDerivation transforms data in catalog format into a fake derivation with a store path that
 # can be substituted
-{lib}: element: let
-  fromSource = with element.element;
+{lib}: publishData: let
+  eval =
+    (publishData.eval or {})
+    // {
+      # if a storePath is published, it might not have outputs or outputsToInstall
+      # TODO: fix this on the publish/readPackage side
+      meta = {outputsToInstall = ["out"];} // (publishData.eval.meta or {});
+      outputs = publishData.eval.outputs or {"out" = lib.head publishData.element.storePaths;};
+    };
+  fromSource = with publishData.element;
     if url == ""
     then throw "url = \"\" so this fakeDerivation can't be built from source. Note that fakeDerivations created from self cannot be built from source"
     else lib.getAttrFromPath attrPath (builtins.getFlake url);
@@ -19,9 +27,9 @@
   getOutPath = outputName: let
     stringOutPath = outputs.${outputName};
     cacheUrl =
-      if element ? cache
+      if publishData ? cache
       then
-        if builtins.isList element.cache
+        if builtins.isList publishData.cache
         # builtfilter style cache entry
         # cache = [
         #   {
@@ -39,12 +47,12 @@
             cacheUrl: cacheMetadata:
               if cacheUrl != null
               then cacheUrl
-              else if builtins.any (narinfo: narinfo.path == stringOutPath) cacheMetadata
+              else if builtins.any (narinfo: narinfo.path == stringOutPath) (cacheMetadata.narinfo or [])
               then cacheMetadata.cacheUrl
               else null
           )
           null
-          element.cache
+          publishData.cache
         # update-catalog style cache entry
         # cache = {
         #   out = {
@@ -54,16 +62,16 @@
         #     };
         #   };
         # };
-        else if element.cache ? ${outputName}
+        else if publishData.cache ? ${outputName}
         then
           builtins.foldl' (foundCacheUrl: cacheUrl:
             if foundCacheUrl != null
             then foundCacheUrl
-            else if element.cache.${outputName}.${cacheUrl}.valid or null == "false"
+            else if publishData.cache.${outputName}.${cacheUrl}.valid or null == "false"
             then null
             # absence of valid means an entry is valid
             else cacheUrl)
-          null (builtins.attrNames element.cache.${outputName})
+          null (builtins.attrNames publishData.cache.${outputName})
         else null
       else null;
   in
@@ -78,16 +86,16 @@
       else builtins.storePath stringOutPath
     else fromSource.${outputName};
 
-  outputs = element.eval.outputs or (throw "unable to create mkFakeDerivation: no eval.outputs");
+  outputs = eval.outputs or (throw "unable to create mkFakeDerivation: no eval.outputs");
   outputNames = builtins.attrNames outputs;
   defaultOutput = builtins.head outputNames;
   common =
     {
-      name = element.eval.name or "unnamed";
-      version = element.eval.version or null;
-      pname = element.eval.pname or null;
-      meta = element.eval.meta or {};
-      system = element.eval.system;
+      name = eval.name or "unnamed";
+      version = eval.version or null;
+      pname = eval.pname or null;
+      meta = eval.meta or {};
+      system = eval.system;
     }
     // outputsSet
     //
@@ -118,7 +126,7 @@ in
   (derivation
     {
       name = defaultOut.name;
-      system = element.eval.system;
+      system = eval.system;
       builder = "builtin:buildenv";
       manifest = outputsSet.${defaultOutput};
       derivations =
@@ -129,7 +137,7 @@ in
   // {
     # We ensured all outputsToInstall are wrapped by this buildenv, and this buildenv will only have
     # a single output, so we shouldn't pass outputsToInstall through
-    meta = builtins.removeAttrs defaultOut.meta ["outputsToInstall"] // {inherit element;};
+    meta = builtins.removeAttrs defaultOut.meta ["outputsToInstall"] // {inherit publishData;};
     pname = defaultOut.pname;
     version = defaultOut.version;
     inherit fromSource;

--- a/plugins/catalog.nix
+++ b/plugins/catalog.nix
@@ -87,22 +87,12 @@
     (_: a: !(a ? element.storePaths))
     # f
     (
-      path: x:
+      path: publishData:
       # mapAttrsRecursiveCondFunc calls this function on leaves even if cond is not met (**which deviates from stdlib**), so we
       # have to double check cond
       # TODO: use `type == "flakeRender"` as condition
-        if (x ? element.storePaths)
-        then
-          (self.lib.mkFakeDerivation
-            {
-              eval =
-                (x.eval or {})
-                // {
-                  meta = {outputsToInstall = ["out"];} // (x.eval.meta or {});
-                  outputs = x.eval.outputs or {"out" = lib.head x.element.storePaths;};
-                };
-              inherit (x) element;
-            })
+        if (publishData ? element.storePaths)
+        then self.lib.mkFakeDerivation publishData
         else throw "encountered a leaf that doesn't have storePaths"
     )
     catalogData;


### PR DESCRIPTION
The catalog plugin should not be dropping any data from publishData. In particular, this fixes the assumption in mkFakeDerivation that cache is passed. Also rename element -> publishData (this is a historical name from nix profile manifest elements)