### PR TITLE
fix: mkFakeDerivation related bugs

### DIFF
--- a/lib/mkEnv.nix
+++ b/lib/mkEnv.nix
@@ -66,9 +66,9 @@ let
       elements =
         map (
           v:
-            if v ? meta.element.element
+            if v ? meta.publishData.element
             then let
-              el = v.meta.element.element;
+              el = v.meta.publishData.element;
             in
               el
               // {

--- a/lib/mkFakeDerivation.nix
+++ b/lib/mkFakeDerivation.nix
@@ -67,7 +67,7 @@
           builtins.foldl' (foundCacheUrl: cacheUrl:
             if foundCacheUrl != null
             then foundCacheUrl
-            else if publishData.cache.${outputName}.${cacheUrl}.valid or null == "false"
+            else if publishData.cache.${outputName}.${cacheUrl}.valid or null == false
             then null
             # absence of valid means an entry is valid
             else cacheUrl)


### PR DESCRIPTION
- valid is a boolean not a string
- mkEnv was missed in the recent rename of element