### PR TITLE
init: inline packages via capacitor

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1674143945,
-        "narHash": "sha256-Td11lB1GkgiLjaFTm3VGjuU8IK0qoortU8Ly3+IQ2dg=",
+        "lastModified": 1674744320,
+        "narHash": "sha256-c//y7XrgO6DN4f/qplL8RzQggBLx8Aj4GHXIr40FjGs=",
         "owner": "flox",
         "repo": "capacitor",
-        "rev": "ed884ec0668aa9f59c3c4d1883a478705054e282",
+        "rev": "3a1505cf9f13f6e44c882d9f3c69dcafbd0462e1",
         "type": "github"
       },
       "original": {

--- a/plugins/floxEnvs.nix
+++ b/plugins/floxEnvs.nix
@@ -7,7 +7,7 @@
   injectedArgs ? {},
   dir ? sourceType,
 }: let
-  materialize = lib.capacitor.capacitate.capacitate.materialize;
+  materialize = lib.capacitor.capacitate.materialize;
 in
   {context, ...}: let
     floxEnvsMapper = context: {


### PR DESCRIPTION
- [ ] bump the lock in flox-bash-private template lock

Usage:
```
{
  packages.nixpkgs-flox.hello = {version = "2.10";};
  packages.nixpkgs-flox.ran = {};
  packages.nixpkgs-flox.cheat = {};
  packages.nixpkgs-flox.ripgrep = {};
  packages.nixpkgs-flox.jq = {};

  derivations = {
    packages.env = {python3}:
      python3.withPackages (ps: with ps; []);
  };
}
```