### PR TITLE
fix: ensure manfest.nix has non-colliding contents

### DIFF
--- a/lib/mkFakeDerivation.nix
+++ b/lib/mkFakeDerivation.nix
@@ -128,7 +128,7 @@ in
       name = defaultOut.name;
       system = eval.system;
       builder = "builtin:buildenv";
-      manifest = outputsSet.${defaultOutput};
+      manifest = "/nix";
       derivations =
         map (x: ["true" 5 1 outputsSet.${x}]) (defaultOut.meta.outputsToInstall or defaultOut.outputs);
     })


### PR DESCRIPTION
Currently the contents of manifest.nix will often collide, e.g. a reproducer is flox install clang cloog

/nix will always exist, so it won't emit warnings about dangling symlinks, and it will also never collide