### PR TITLE
feat: pass specialized context to flox envs

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -8,7 +8,7 @@
 }: let
   # Assumption that flox-floxpkgs is a direct input
   floxpkgs = context.inputs.flox-floxpkgs;
-  pkgs = context.nixpkgs.legacyPackages.${system};
+  pkgs = context.nixpkgs;
 in {
   options = with lib; {
     inline = mkOption {

--- a/modules/container.nix
+++ b/modules/container.nix
@@ -7,7 +7,7 @@
   ...
 }: let
   floxpkgs = context.inputs.flox-floxpkgs;
-  pkgs = context.nixpkgs.legacyPackages.${system};
+  pkgs = context.nixpkgs;
 in {
   options.container = with lib; {
     name = mkOption {

--- a/modules/shells/posix.nix
+++ b/modules/shells/posix.nix
@@ -7,7 +7,7 @@
   ...
 }: let
   floxpkgs = context.inputs.flox-floxpkgs;
-  pkgs = context.nixpkgs.legacyPackages.${system};
+  pkgs = context.nixpkgs;
 in
   with lib; {
     # common options for POSIX compatible shells

--- a/plugins/floxEnvs.nix
+++ b/plugins/floxEnvs.nix
@@ -34,7 +34,8 @@ in
       value =
         lib.recursiveUpdate
         (self.lib.mkFloxEnv {
-          inherit context system namespace;
+          inherit system namespace;
+          context = context.context' system;
           modules = [floxNixPath] ++ lib.optional (builtins.pathExists catalogPath) {inherit catalogPath;};
         }) {meta.position = builtins.unsafeDiscardStringContext floxNixPath;};
       path = [system] ++ namespace;

--- a/plugins/rootFloxEnvs.nix
+++ b/plugins/rootFloxEnvs.nix
@@ -9,7 +9,8 @@
   namespace = ["default"];
   result = lib.genAttrs context.systems (system: {
     default = lib.recursiveUpdate (self.lib.mkFloxEnv {
-      inherit context system namespace;
+      inherit system namespace;
+      context = context.context' system;
       modules = [floxNixPath] ++ lib.optional (builtins.pathExists catalogPath) {inherit catalogPath;};
     }) {meta.position = builtins.unsafeDiscardStringContext floxNixPath;};
   });


### PR DESCRIPTION
This is the follow up on the merged capacitor changes, allowing you to pass a system specialized context to the modules.
This is generally more consistent with how we use to call functions elsewhere when we have access to `system`