### PR TITLE
fix: default container.created to 1970

### DIFF
--- a/modules/container.nix
+++ b/modules/container.nix
@@ -57,7 +57,7 @@ in {
     created = mkOption {
       description = lib.mdDoc ''Date and time the layers were created.'';
       type = types.str;
-      default = "now";
+      default = "1970-01-01T00:00:02Z";
     };
 
     maxLayers = mkOption {


### PR DESCRIPTION
Otherwise layers are never reused

I'm planning to tweak the script to allow both "now" and reuse, but for now allow reuse