### PR TITLE
feat: support allowUnfree configuration in flakes

### DIFF
--- a/lib/mkFakeDerivation.nix
+++ b/lib/mkFakeDerivation.nix
@@ -16,7 +16,7 @@
     fromNixpkgs = builtins.match "github:flox/nixpkgs/.*" publishData.element.url != null;
     # implement allowedUnfreePackages as allowUnfreePredicate, but still honor
     # allowUnfreePredicate
-    attrPath = builtins.tail (builtins.tail publishData.element.attrPath);
+    shortAttrPath = builtins.tail (builtins.tail publishData.element.attrPath);
     allowUnfreePredicate =
       if context ? config.nixpkgs-config.allowUnfreePredicate
       then
@@ -27,7 +27,7 @@
       then
         # cheat here: we know at this point that this predicate will only be used
         # once, so we can set it to always return true or false
-        if builtins.elem (builtins.concatStringsSep "." attrPath) context.config.nixpkgs-config.allowedUnfreePackages
+        if builtins.elem (builtins.concatStringsSep "." shortAttrPath) context.config.nixpkgs-config.allowedUnfreePackages
         then _: true
         else _: false
       else _: false;
@@ -56,7 +56,7 @@
         system = pkgSystem;
       };
     in
-      lib.getAttrFromPath attrPath pkgs
+      lib.getAttrFromPath shortAttrPath pkgs
     else
       with publishData.element;
         if url == ""

--- a/lib/mkFakeDerivation.nix
+++ b/lib/mkFakeDerivation.nix
@@ -60,7 +60,7 @@
     else
       with publishData.element;
         if url == ""
-        then throw "url = \"\" so this fakeDerivation can't be built from source. Note that fakeDerivations created from self cannot be built from source"
+        then throw "Not possible to build from source; url = \"\". Note that fakeDerivations created from self cannot be built from source"
         else lib.getAttrFromPath attrPath (builtins.getFlake url);
 
   # We could be

--- a/lib/mkFakeDerivation.nix
+++ b/lib/mkFakeDerivation.nix
@@ -1,6 +1,9 @@
 # mkFakeDerivation transforms data in catalog format into a fake derivation with a store path that
 # can be substituted
-{lib}: publishData: let
+{lib}: {
+  publishData,
+  context,
+}: let
   eval =
     (publishData.eval or {})
     // {
@@ -9,10 +12,47 @@
       meta = {outputsToInstall = ["out"];} // (publishData.eval.meta or {});
       outputs = publishData.eval.outputs or {"out" = lib.head publishData.element.storePaths;};
     };
-  fromSource = with publishData.element;
-    if url == ""
-    then throw "url = \"\" so this fakeDerivation can't be built from source. Note that fakeDerivations created from self cannot be built from source"
-    else lib.getAttrFromPath attrPath (builtins.getFlake url);
+  fromSource = let
+    fromNixpkgs = builtins.match "github:flox/nixpkgs/.*" publishData.element.url != null;
+    # implement allowedUnfreePackages as allowUnfreePredicate, but still honor
+    # allowUnfreePredicate
+    allowUnfreePredicate =
+      if context ? config.nixpkgs-config.allowUnfreePredicate
+      then
+        if context ? config.nixpkgs-config.allowedUnfreePackages
+        then throw "only one of allowedUnfreePackages and allowUnfreePredicate can be specified in config.nixpkgs-config"
+        else context.config.nixpkgs-config.allowUnfreePredicate
+      else if context ? config.nixpkgs-config.allowedUnfreePackages
+      then pkg: builtins.elem (lib.getName pkg) context.config.nixpkgs-config.allowedUnfreePackages
+      else _: false;
+    # based on stdenv check-meta.nix
+    hasDeniedUnfreeLicense =
+      eval.meta.unfree
+      && !(context.config.nixpkgs-config.allowUnfree or false)
+      && !(allowUnfreePredicate eval.pname);
+  in
+    if
+      fromNixpkgs
+      && hasDeniedUnfreeLicense
+    then throw "Encountered unfree package ${eval.pname} that is not allowed; add exceptions to the flake's config.nixpkgs-config"
+    else if fromNixpkgs
+    then let
+      pkgSystem =
+        if builtins.head publishData.element.attrPath != "legacyPackages"
+        then throw "first element of attrPath in nixpkgs not equal to legacyPackages"
+        else builtins.elemAt publishData.element.attrPath 1;
+      nixpkgsFlake = builtins.getFlake publishData.element.url;
+      pkgs = import nixpkgsFlake {
+        config = (builtins.removeAttrs context.config.nixpkgs-config ["allowedUnfreePackages"]) // {inherit allowUnfreePredicate;};
+        system = pkgSystem;
+      };
+    in
+      lib.getAttrFromPath (builtins.tail (builtins.tail publishData.element.attrPath)) pkgs
+    else
+      with publishData.element;
+        if url == ""
+        then throw "url = \"\" so this fakeDerivation can't be built from source. Note that fakeDerivations created from self cannot be built from source"
+        else lib.getAttrFromPath attrPath (builtins.getFlake url);
 
   # We could be
   # 1. using an entry from the catalog that has a cache hit

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -310,8 +310,10 @@ in {
           packageAttrSet: let
             catalogPath = catalogPathGetter channelName packageAttrSet.attrPath packageAttrSet.packageConfig;
           in rec {
-            fakeDerivation =
-              floxpkgs.lib.mkFakeDerivation (lib.getAttrFromPath catalogPath catalog);
+            fakeDerivation = floxpkgs.lib.mkFakeDerivation {
+              inherit context;
+              publishData = lib.getAttrFromPath catalogPath catalog;
+            };
             publishData = fakeDerivation.meta.publishData;
             # for informative error messages
             inherit channelName;
@@ -384,7 +386,7 @@ in {
             #   called in this file
             # - wrap derivations from flakes in a fake derivation, because that's what
             #   will happen once they are put in the catalog
-            fakeDerivation = floxpkgs.lib.mkFakeDerivation publishData;
+            fakeDerivation = floxpkgs.lib.mkFakeDerivation {inherit context publishData;};
           in
             # this function returns just the entries for this channel, and the caller adds channelName to the complete catalog
             rec {

--- a/plugins/catalog.nix
+++ b/plugins/catalog.nix
@@ -92,7 +92,7 @@
       # have to double check cond
       # TODO: use `type == "flakeRender"` as condition
         if (publishData ? element.storePaths)
-        then self.lib.mkFakeDerivation publishData
+        then self.lib.mkFakeDerivation {inherit context publishData;}
         else throw "encountered a leaf that doesn't have storePaths"
     )
     catalogData;

--- a/templates/_init/flake.nix
+++ b/templates/_init/flake.nix
@@ -7,6 +7,7 @@
     flox-floxpkgs.project args (_: {
       config.nixpkgs-config = {
         allowUnfree = false;
+        # e.g. "vscode"
         allowedUnfreePackages = [];
       };
     });

--- a/templates/_init/flake.nix
+++ b/templates/_init/flake.nix
@@ -3,5 +3,11 @@
 
   inputs.flox-floxpkgs.url = "github:flox/floxpkgs";
 
-  outputs = args @ {flox-floxpkgs, ...}: flox-floxpkgs.project args (_: {});
+  outputs = args @ {flox-floxpkgs, ...}:
+    flox-floxpkgs.project args (_: {
+      config.nixpkgs-config = {
+        allowUnfree = false;
+        allowedUnfreePackages = [];
+      };
+    });
 }


### PR DESCRIPTION
Packages will be built from source if the toplevel flake has allowUnfree
set to true. It also introduces a new config option
allowedUnfreePackages, which would be nice to upstream. See
https://github.com/NixOS/nixpkgs/issues/55674