### PR TITLE
fix: don't realize fakeDerivation for catalog.json

### DIFF
--- a/lib/readPackage.nix
+++ b/lib/readPackage.nix
@@ -26,6 +26,7 @@
   element = rec {
     active = true;
     inherit attrPath;
+    # TODO deduplicate with logic for floxEnvs
     # normalize to include "flake:", which is included in manifest.json
     originalUrl =
       if flakeRef == "self"
@@ -36,6 +37,8 @@
           then flakeRef
           else "flake:${flakeRef}"
         );
+    # TODO deduplicate with logic for floxEnvs and figure out a better way to
+    # store flake resolution information
     url =
       if flakeRef == "self"
       then ""

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -576,5 +576,6 @@ in {
     };
 
     passthru.inline = inline;
+    passthru.catalog = builtins.toJSON newCatalog;
   };
 }


### PR DESCRIPTION
Currently determining the contents of manifest.json and catalog.json requires realizing the storePath for a fakeDerivation. This is undesirable since we should be able to eval a catalog without performing any intensive operations in order to determine the available upgrades for an environment. Instead of realizing the fakeDerivation storePath, just pass through the storePaths that it wraps

Helps https://github.com/flox/product/issues/155

This means manifest.json and catalog.json may contain a storePaths with multiple storePaths rather than just a single one, and the output of flox list changes from:
```
Packages
    0  stable.nixpkgs-flox.curl  /nix/store/07zipzdqcldqz5f6wdarc2dlxmwbydi9-curl-7.86.0
```

To:
```
Packages
    0  stable.nixpkgs-flox.curl  /nix/store/8nv1g4ymxi2f96pbl1jy9h625v2risd8-curl-7.86.0-bin,/nix/store/i6jgil3y6pdbgi29vrsz8frg0y4d02lp-curl-7.86.0-man
```