### PR TITLE
feat: rename inline to integrations

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -591,4 +591,7 @@ in {
     passthru.inline = inline;
     passthru.catalog = builtins.toJSON newCatalog;
   };
+  imports = [
+    (lib.mkAliasOptionModule ["integrations"] ["inline"])
+  ];
 }


### PR DESCRIPTION
Allows for an alias of "integrations" instead of the awkward "inline".