### PR TITLE
feat: add installedStorePaths passthru

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -588,6 +588,8 @@ in {
 
     passthru.inline = inline;
     passthru.catalog = builtins.toJSON newCatalog;
+    # packages installed by store path,
+    # for which no further information can be derived
     passthru.installedStorePaths = sortedStorePaths;
   };
   imports = [

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -588,6 +588,7 @@ in {
 
     passthru.inline = inline;
     passthru.catalog = builtins.toJSON newCatalog;
+    passthru.installedStorePaths = sortedStorePaths;
   };
   imports = [
     (lib.mkAliasOptionModule ["integrations"] ["inline"])


### PR DESCRIPTION
`flox list` needs to be able to list the storePaths in a floxEnv. That information is currently present in manifest.json, but manifest.json is being deprecated.

Store paths could be added to catalog.json, but that would be abusing the purpose of the catalog. The purpose of the catalog is to express invariants about derivations. Adding a store path to a catalog would only express "this store path was present on some machine at some time" which is a useless guarantee. Additionally, a catalog entry for a store path would contain exactly the same information as the flox.nix file, which would mean useless duplication.