### PR TITLE
fix: don't call toJSON

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -587,7 +587,7 @@ in {
     };
 
     passthru.inline = inline;
-    passthru.catalog = builtins.toJSON newCatalog;
+    passthru.catalog = newCatalog;
   };
   imports = [
     (lib.mkAliasOptionModule ["integrations"] ["inline"])


### PR DESCRIPTION
runix invokes nix eval with --json, which turns the output of toJSON into a single string rather than actual JSON