### PR TITLE
activate: set FLOX_ENV and source <env>/etc/profile

### DIFF
--- a/lib/mkEnv.nix
+++ b/lib/mkEnv.nix
@@ -156,6 +156,7 @@ in
         if [ -f "${profile}/env.bash" ]; then
           source "${profile}/env.bash"
         fi
+        export FLOX_ENV="${profile}";
         if [ -f "${profile}/activate" ]; then
           source "${profile}/activate"
         fi

--- a/modules/shells/posix.nix
+++ b/modules/shells/posix.nix
@@ -62,7 +62,7 @@ in
           else (mapAttrsToList (n: v: ''export ${n}=${escapeShellArg v};'') config.environmentVariables);
       in
         concatStringsSep "\n" exportVariables;
-      activateScript = envOut: pkgs.writeTextFile {
+      activateScript = pkgs.writeTextFile {
         name = "activate";
         executable = true;
         destination = "/activate";
@@ -83,8 +83,7 @@ in
       passthru.posix = floxpkgs.lib.mkEnv {
         inherit pkgs;
         packages = config.packagesList ++ [
-          config.newCatalogPath
-          ( activateScript ( builtins.placeholder "out" ) )
+          config.newCatalogPath activateScript
         ];
         manifestPath = config.manifestPath;
         meta.buildLayeredImageArgs = config.passthru.buildLayeredImageArgs;


### PR DESCRIPTION
Sets a variable `FLOX_ENV` pointing to the root of the environment being activated for convenient usage in `shell.hook`.

Additionally checks for `<env>/etc/profile` and sources it if one exists. This will allow users to `flox install` a robust hook to be used in multiple environments and shared with others.