### PR TITLE
fix: only substitute if valid == true

### DIFF
--- a/lib/mkFakeDerivation.nix
+++ b/lib/mkFakeDerivation.nix
@@ -37,6 +37,7 @@
         #     narinfo = [
         #       {
         #         path = "/nix/store/XXX";
+        #         valid = false;
         #         ...
         #       }
         #     ];
@@ -47,7 +48,7 @@
             cacheUrl: cacheMetadata:
               if cacheUrl != null
               then cacheUrl
-              else if builtins.any (narinfo: narinfo.path == stringOutPath) (cacheMetadata.narinfo or [])
+              else if builtins.any (narinfo: narinfo.path == stringOutPath && narinfo.valid == true) (cacheMetadata.narinfo or [])
               then cacheMetadata.cacheUrl
               else null
           )


### PR DESCRIPTION
    Currently substitution will be attempted even when valid == false. This
    results in the error "path ... does not exist and cannot be created"
    being displayed to the user rather than the correct behavior of
    attempting to build from source.