### PR TITLE
feat: link propagated build inputs in floxEnvs

### DIFF
--- a/.github/workflows/etc-profiles.yml
+++ b/.github/workflows/etc-profiles.yml
@@ -49,7 +49,7 @@ jobs:
         selfURI="github:${{ github.repository }}/${{ github.sha }}";
 
         git init;
-        flox init --template "$selfURI#etc-profiles" --name sqlite-dev;
+        flox init --template "$selfURI#profile" --name sqlite-dev;
         sed -i -e 's/##//' -e 's/sqlite/krb5/' -e 's/"bin" //' ./flox.nix;
         echo '---';
         cat ./flox.nix;

--- a/.github/workflows/etc-profiles.yml
+++ b/.github/workflows/etc-profiles.yml
@@ -49,7 +49,7 @@ jobs:
         selfURI="github:${{ github.repository }}/${{ github.sha }}";
 
         git init;
-        flox init --template "$selfURI#profile" --name sqlite-dev;
+        flox init --template "$selfURI#etc-profiles" --name sqlite-dev;
         sed -i -e 's/##//' -e 's/sqlite/krb5/' -e 's/"bin" //' ./flox.nix;
         echo '---';
         cat ./flox.nix;

--- a/.github/workflows/etc-profiles.yml
+++ b/.github/workflows/etc-profiles.yml
@@ -48,7 +48,8 @@ jobs:
 
         selfURI="github:${{ github.repository }}/${{ github.sha }}";
 
-        flox init --init-git --template "$selfURI#profile" --name sqlite-dev;
+        git init;
+        flox init --template "$selfURI#profile" --name sqlite-dev;
         sed -i -e 's/##//' -e 's/sqlite/krb5/' -e 's/"bin" //' ./flox.nix;
         echo '---';
         cat ./flox.nix;

--- a/flake.lock
+++ b/flake.lock
@@ -177,18 +177,17 @@
         "ld-floxlib": "ld-floxlib"
       },
       "locked": {
-        "lastModified": 1686898756,
-        "narHash": "sha256-fVRVU1huhuLas9VM/W//zivzSzpVfKhw1Xr5Ga16YLQ=",
-        "ref": "brantley",
-        "rev": "ce0f87e6c2746a571575665b3427eee7cac724e0",
-        "revCount": 56,
-        "type": "git",
-        "url": "ssh://git@github.com/flox/etc-profiles"
+        "lastModified": 1687974724,
+        "narHash": "sha256-sSZn+RJ7oqs47Lt21Kgj13llfWq1RqnoYeBoodUPFXU=",
+        "owner": "flox",
+        "repo": "etc-profiles",
+        "rev": "cbe328273489ff06c91d7a1c15bb52dfd8356689",
+        "type": "github"
       },
       "original": {
-        "ref": "brantley",
-        "type": "git",
-        "url": "ssh://git@github.com/flox/etc-profiles"
+        "owner": "flox",
+        "repo": "etc-profiles",
+        "type": "github"
       }
     },
     "flake-compat": {
@@ -489,15 +488,15 @@
       "locked": {
         "lastModified": 1686896430,
         "narHash": "sha256-VA9ywbsxHU1vbaTNmVuXaS4Rj2hPCJw9cCpuBVZb97Q=",
-        "ref": "refs/heads/main",
+        "owner": "flox",
+        "repo": "ld-floxlib",
         "rev": "211c74dead2d2f0aff39f46f02d93806630c8fdd",
-        "revCount": 10,
-        "type": "git",
-        "url": "ssh://git@github.com/flox/ld-floxlib"
+        "type": "github"
       },
       "original": {
-        "type": "git",
-        "url": "ssh://git@github.com/flox/ld-floxlib"
+        "owner": "flox",
+        "repo": "ld-floxlib",
+        "type": "github"
       }
     },
     "nixpkgs": {
@@ -518,11 +517,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1686445117,
-        "narHash": "sha256-QfbAtKFmh92rv0j1e9d7EDgPLDERn1EY6FGXwKG09SM=",
+        "lastModified": 1687654967,
+        "narHash": "sha256-ki8vItcjn8Z8n+QD9NEoCQbbbG7VzWy71hyOkFFwCkM=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a08e40a9bc625b7ee428bd7b64cdcff516023c5d",
+        "rev": "b3ec8fb525fc0c8f08eff5ef93c684b4c6d0e777",
         "type": "github"
       },
       "original": {
@@ -563,11 +562,11 @@
     },
     "nixpkgs-lib_4": {
       "locked": {
-        "lastModified": 1686445117,
-        "narHash": "sha256-QfbAtKFmh92rv0j1e9d7EDgPLDERn1EY6FGXwKG09SM=",
+        "lastModified": 1687654967,
+        "narHash": "sha256-ki8vItcjn8Z8n+QD9NEoCQbbbG7VzWy71hyOkFFwCkM=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a08e40a9bc625b7ee428bd7b64cdcff516023c5d",
+        "rev": "b3ec8fb525fc0c8f08eff5ef93c684b4c6d0e777",
         "type": "github"
       },
       "original": {
@@ -658,11 +657,11 @@
     },
     "nixpkgs-staging_2": {
       "locked": {
-        "lastModified": 1684754342,
-        "narHash": "sha256-plGnjnbnPLoZCTdQX21oT7xliQhFtgcWlkuDHgtEb1o=",
+        "lastModified": 1687661089,
+        "narHash": "sha256-RhF9PiNfOQpm/Q2BR+2305KDR9FCXD6QJizbZ5vxVvQ=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "7084250df3d7f9735087d3234407f3c1fc2400e3",
+        "rev": "f742512ccc99e6ac457d6d4ddce78f283c4bbfde",
         "type": "github"
       },
       "original": {
@@ -690,11 +689,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1684754342,
-        "narHash": "sha256-plGnjnbnPLoZCTdQX21oT7xliQhFtgcWlkuDHgtEb1o=",
+        "lastModified": 1687681650,
+        "narHash": "sha256-M2If+gRcfpmaJy/XbfSsRzLlPpoU4nr0NHnKKl50fd8=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "7084250df3d7f9735087d3234407f3c1fc2400e3",
+        "rev": "1c9db9710cb23d60570ad4d7ab829c2d34403de3",
         "type": "github"
       },
       "original": {
@@ -725,11 +724,11 @@
         "nixpkgs__flox__x86_64-linux": "nixpkgs__flox__x86_64-linux_2"
       },
       "locked": {
-        "lastModified": 1686770319,
-        "narHash": "sha256-9ffqbrKUa0g2aql8B8SDXTCDzyU8PnW7JI1uisuk0dQ=",
+        "lastModified": 1687788718,
+        "narHash": "sha256-0IPnixb1LudsHyMSbBh+nJjZNlnbTbFEraoRDlMG7mg=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "48e8d0cfdc7bc98e9bf4d65a67ea324b3d952ea7",
+        "rev": "7ef6e4b3523b3d4d0d6ba5bd6c945671fa965c99",
         "type": "github"
       },
       "original": {
@@ -913,11 +912,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1686769905,
-        "narHash": "sha256-3bTAKno+hbVkaj/7nIuG8CgBuS347E6ksPcwwjcMw78=",
+        "lastModified": 1687788253,
+        "narHash": "sha256-gz19wXdw2JHZX9i3lE50xQn0kHWJSDrdP/8aJuNx/DY=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "7800311cb0d5c8970021f9f6691115feb0be7c04",
+        "rev": "026a271a78fa569989010b6ebdba66381870cde7",
         "type": "github"
       },
       "original": {
@@ -951,11 +950,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1686769880,
-        "narHash": "sha256-t5LMiPoNgzB6UKBvUzMlsC3vcYvKoWT6InPHpTf6QNo=",
+        "lastModified": 1687788220,
+        "narHash": "sha256-GSBPBUixzI+Y+GrLwLM56w/zTLVd9pHOJIVUYoyNhnY=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "234e8b5adf58fe3b1b6a33680f0a6ba8d8b639d0",
+        "rev": "67623a9ab10d435557920e9a598ba8d7632fe48c",
         "type": "github"
       },
       "original": {
@@ -989,11 +988,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1686770241,
-        "narHash": "sha256-2EJ6vCG+iMklp4mcUGhZPJk7brx2fHn2fHUYKjtJI34=",
+        "lastModified": 1687788598,
+        "narHash": "sha256-KqAPNxWj9WyVEXVc9+gCy1AuocpIhqospyTSJcxS/oU=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "cd8107202cd66d4047d2f1decb29cf03ad6195cd",
+        "rev": "bab1f9dcf3ebd32e7fd09daa71300c1e0e52cb9d",
         "type": "github"
       },
       "original": {
@@ -1027,11 +1026,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1686770232,
-        "narHash": "sha256-DFuwK3Vul8z9va99vpcWmz32WBv4Hd5tIT/qWdkG/bo=",
+        "lastModified": 1687788584,
+        "narHash": "sha256-Ffc/XVvi+dM8iGEN0qAw5kNcoHKqhvSF1wL5+RM6yu0=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "21a6177aae1307aaabc94cacff8f729495fa9df0",
+        "rev": "9322182bb1d53541954eabe274e041b3bedbbb57",
         "type": "github"
       },
       "original": {
@@ -1065,11 +1064,11 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1686770212,
-        "narHash": "sha256-Nf8RF6JYjlw65DvBQfkEz2Ev6UFyCM38oPJEIXKNfXc=",
+        "lastModified": 1687788554,
+        "narHash": "sha256-k0nGvnhAoxkxsOxIJ+B1smDowHwExo5+/yemmnH8RoE=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "209643b52be208bca6eae3a8df22a2e9ea8c175f",
+        "rev": "ff93610b257d149a5c5cf2ee2b9b90f9ed92b587",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -19,6 +19,29 @@
         "type": "github"
       }
     },
+    "builtfilter_2": {
+      "inputs": {
+        "flox-floxpkgs": [
+          "etc-profiles",
+          "ld-floxlib",
+          "flox-floxpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1683889736,
+        "narHash": "sha256-Sxn6VNrojAl9Tu0dDy6ZqPUe0GNwRKwzHAkptXM63Wg=",
+        "owner": "flox",
+        "repo": "builtfilter",
+        "rev": "f29903b144bb20e5be80f55d3fafa323c28a2cb0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "builtfilter-rs",
+        "repo": "builtfilter",
+        "type": "github"
+      }
+    },
     "capacitor": {
       "inputs": {
         "nixpkgs": "nixpkgs",
@@ -41,11 +64,34 @@
     },
     "capacitor_2": {
       "inputs": {
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1675629156,
+        "narHash": "sha256-55UOZa4MUTgCwyK8jrskwFLATDuMAvXyC7GGcsF45Xg=",
+        "owner": "flox",
+        "repo": "capacitor",
+        "rev": "0694a193660db2cb1a7a6e04949478b25f81d802",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "v0",
+        "repo": "capacitor",
+        "type": "github"
+      }
+    },
+    "capacitor_3": {
+      "inputs": {
         "nixpkgs": [
+          "etc-profiles",
+          "ld-floxlib",
+          "flox-floxpkgs",
           "nixpkgs",
           "nixpkgs"
         ],
-        "nixpkgs-lib": "nixpkgs-lib_2"
+        "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
         "lastModified": 1675629156,
@@ -59,6 +105,90 @@
         "owner": "flox",
         "repo": "capacitor",
         "type": "github"
+      }
+    },
+    "capacitor_4": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs",
+          "nixpkgs"
+        ],
+        "nixpkgs-lib": "nixpkgs-lib_4"
+      },
+      "locked": {
+        "lastModified": 1675629156,
+        "narHash": "sha256-55UOZa4MUTgCwyK8jrskwFLATDuMAvXyC7GGcsF45Xg=",
+        "owner": "flox",
+        "repo": "capacitor",
+        "rev": "0694a193660db2cb1a7a6e04949478b25f81d802",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "repo": "capacitor",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_3",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1686621798,
+        "narHash": "sha256-FUwWszmSiDzUdTk8f69xwMoYlhdPaLvDaIYOE/y6VXc=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "75f7d715f8088f741be9981405f6444e2d49efdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_7",
+        "rust-overlay": "rust-overlay_2"
+      },
+      "locked": {
+        "lastModified": 1686621798,
+        "narHash": "sha256-FUwWszmSiDzUdTk8f69xwMoYlhdPaLvDaIYOE/y6VXc=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "75f7d715f8088f741be9981405f6444e2d49efdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "etc-profiles": {
+      "inputs": {
+        "flox-floxpkgs": [],
+        "ld-floxlib": "ld-floxlib"
+      },
+      "locked": {
+        "lastModified": 1686898756,
+        "narHash": "sha256-fVRVU1huhuLas9VM/W//zivzSzpVfKhw1Xr5Ga16YLQ=",
+        "ref": "brantley",
+        "rev": "ce0f87e6c2746a571575665b3427eee7cac724e0",
+        "revCount": 56,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/etc-profiles"
+      },
+      "original": {
+        "ref": "brantley",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/etc-profiles"
       }
     },
     "flake-compat": {
@@ -77,13 +207,118 @@
         "type": "github"
       }
     },
-    "flake-utils": {
+    "flake-compat_2": {
+      "flake": false,
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -94,7 +329,26 @@
     },
     "floco": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_4"
+      },
+      "locked": {
+        "lastModified": 1684245865,
+        "narHash": "sha256-CJSxo7fvAAjdMaQWALyNG6LKMjOGZC/uxlbX1KuegWU=",
+        "owner": "aakropotkin",
+        "repo": "floco",
+        "rev": "e1231f054258f7d62652109725881767765b1efb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "aakropotkin",
+        "repo": "floco",
+        "rev": "e1231f054258f7d62652109725881767765b1efb",
+        "type": "github"
+      }
+    },
+    "floco_2": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_8"
       },
       "locked": {
         "lastModified": 1684245865,
@@ -113,16 +367,65 @@
     },
     "flox": {
       "inputs": {
+        "crane": "crane",
         "floco": "floco",
-        "flox-floxpkgs": [],
+        "flox-floxpkgs": [
+          "etc-profiles",
+          "ld-floxlib",
+          "flox-floxpkgs"
+        ],
         "shellHooks": "shellHooks"
       },
       "locked": {
-        "lastModified": 1685615168,
-        "narHash": "sha256-ZIp5QbR5aiK5Nu1mfYcQEcN+Ez3vFDpzmoi2KF2hDI4=",
+        "lastModified": 1686824858,
+        "narHash": "sha256-29En5YzPyNPTuKbEbc/19R0TjwyS+ZiD+xob+dCocOk=",
         "ref": "latest",
-        "rev": "53f93a799b548107ee5ad199c9284a1fe3b4f1fd",
-        "revCount": 491,
+        "rev": "1ab9bb637a4871c9a8cf9ceaefa1f5b9d8bc8234",
+        "revCount": 519,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox"
+      },
+      "original": {
+        "ref": "latest",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/flox"
+      }
+    },
+    "flox-floxpkgs": {
+      "inputs": {
+        "builtfilter": "builtfilter_2",
+        "capacitor": "capacitor_2",
+        "flox": "flox",
+        "nixpkgs": "nixpkgs_6",
+        "tracelinks": "tracelinks"
+      },
+      "locked": {
+        "lastModified": 1686828047,
+        "narHash": "sha256-KgqjjeWoAvwE+4ie27y+E2ZhwNkU2n3pIKqlJatiJqs=",
+        "owner": "flox",
+        "repo": "floxpkgs",
+        "rev": "d12b0310b8fefe279589fd771d194bca0f560f08",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "repo": "floxpkgs",
+        "type": "github"
+      }
+    },
+    "flox_2": {
+      "inputs": {
+        "crane": "crane_2",
+        "floco": "floco_2",
+        "flox-floxpkgs": [],
+        "shellHooks": "shellHooks_2"
+      },
+      "locked": {
+        "lastModified": 1686824858,
+        "narHash": "sha256-29En5YzPyNPTuKbEbc/19R0TjwyS+ZiD+xob+dCocOk=",
+        "ref": "latest",
+        "rev": "1ab9bb637a4871c9a8cf9ceaefa1f5b9d8bc8234",
+        "revCount": 519,
         "type": "git",
         "url": "ssh://git@github.com/flox/flox"
       },
@@ -133,6 +436,31 @@
       }
     },
     "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "etc-profiles",
+          "ld-floxlib",
+          "flox-floxpkgs",
+          "flox",
+          "shellHooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_2": {
       "inputs": {
         "nixpkgs": [
           "flox",
@@ -152,6 +480,24 @@
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
         "type": "github"
+      }
+    },
+    "ld-floxlib": {
+      "inputs": {
+        "flox-floxpkgs": "flox-floxpkgs"
+      },
+      "locked": {
+        "lastModified": 1686896430,
+        "narHash": "sha256-VA9ywbsxHU1vbaTNmVuXaS4Rj2hPCJw9cCpuBVZb97Q=",
+        "ref": "refs/heads/main",
+        "rev": "211c74dead2d2f0aff39f46f02d93806630c8fdd",
+        "revCount": 10,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/ld-floxlib"
+      },
+      "original": {
+        "type": "git",
+        "url": "ssh://git@github.com/flox/ld-floxlib"
       }
     },
     "nixpkgs": {
@@ -200,23 +546,85 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_3": {
+      "locked": {
+        "lastModified": 1686445117,
+        "narHash": "sha256-QfbAtKFmh92rv0j1e9d7EDgPLDERn1EY6FGXwKG09SM=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "a08e40a9bc625b7ee428bd7b64cdcff516023c5d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_4": {
+      "locked": {
+        "lastModified": 1686445117,
+        "narHash": "sha256-QfbAtKFmh92rv0j1e9d7EDgPLDERn1EY6FGXwKG09SM=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "a08e40a9bc625b7ee428bd7b64cdcff516023c5d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1678872516,
-        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-stable_2": {
+      "locked": {
+        "lastModified": 1684754342,
+        "narHash": "sha256-plGnjnbnPLoZCTdQX21oT7xliQhFtgcWlkuDHgtEb1o=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "7084250df3d7f9735087d3234407f3c1fc2400e3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "stable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_3": {
+      "locked": {
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_4": {
       "locked": {
         "lastModified": 1684754342,
         "narHash": "sha256-plGnjnbnPLoZCTdQX21oT7xliQhFtgcWlkuDHgtEb1o=",
@@ -248,6 +656,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-staging_2": {
+      "locked": {
+        "lastModified": 1684754342,
+        "narHash": "sha256-plGnjnbnPLoZCTdQX21oT7xliQhFtgcWlkuDHgtEb1o=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "7084250df3d7f9735087d3234407f3c1fc2400e3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "staging",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1684754342,
@@ -264,7 +688,89 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable_2": {
+      "locked": {
+        "lastModified": 1684754342,
+        "narHash": "sha256-plGnjnbnPLoZCTdQX21oT7xliQhFtgcWlkuDHgtEb1o=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "7084250df3d7f9735087d3234407f3c1fc2400e3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_10": {
+      "inputs": {
+        "capacitor": "capacitor_4",
+        "flox": [
+          "flox"
+        ],
+        "flox-floxpkgs": [],
+        "nixpkgs": [
+          "nixpkgs",
+          "nixpkgs-stable"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable_4",
+        "nixpkgs-staging": "nixpkgs-staging_2",
+        "nixpkgs-unstable": "nixpkgs-unstable_2",
+        "nixpkgs__flox__aarch64-darwin": "nixpkgs__flox__aarch64-darwin_2",
+        "nixpkgs__flox__aarch64-linux": "nixpkgs__flox__aarch64-linux_2",
+        "nixpkgs__flox__i686-linux": "nixpkgs__flox__i686-linux_2",
+        "nixpkgs__flox__x86_64-darwin": "nixpkgs__flox__x86_64-darwin_2",
+        "nixpkgs__flox__x86_64-linux": "nixpkgs__flox__x86_64-linux_2"
+      },
+      "locked": {
+        "lastModified": 1686770319,
+        "narHash": "sha256-9ffqbrKUa0g2aql8B8SDXTCDzyU8PnW7JI1uisuk0dQ=",
+        "owner": "flox",
+        "repo": "nixpkgs-flox",
+        "rev": "48e8d0cfdc7bc98e9bf4d65a67ea324b3d952ea7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "repo": "nixpkgs-flox",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1684754342,
+        "narHash": "sha256-plGnjnbnPLoZCTdQX21oT7xliQhFtgcWlkuDHgtEb1o=",
+        "owner": "flox",
+        "repo": "nixpkgs",
+        "rev": "7084250df3d7f9735087d3234407f3c1fc2400e3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flox",
+        "ref": "stable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1685714850,
+        "narHash": "sha256-OcvbIJq4CGwwFr9m7M/SQcDPZ64hhR4t77oZgEeh7ZY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c6ffce3d5df7b4c588ce80a0c6e2d2348a611707",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1674236650,
         "narHash": "sha256-B4GKL1YdJnII6DQNNJ4wDW1ySJVx2suB1h/v4Ql8J0Q=",
@@ -278,30 +784,40 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_5": {
       "locked": {
-        "lastModified": 1681303793,
-        "narHash": "sha256-JEdQHsYuCfRL2PICHlOiH/2ue3DwoxUX7DJ6zZxZXFk=",
+        "lastModified": 1685866647,
+        "narHash": "sha256-4jKguNHY/edLYImB+uL8jKPL/vpfOvMmSlLAGfxSrnY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fe2ecaf706a5907b5e54d979fbde4924d84b65fc",
+        "rev": "a53a3bec10deef6e1cc1caba5bc60f53b959b1e8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_6": {
       "inputs": {
-        "capacitor": "capacitor_2",
+        "capacitor": "capacitor_3",
         "flox": [
+          "etc-profiles",
+          "ld-floxlib",
+          "flox-floxpkgs",
           "flox"
         ],
-        "flox-floxpkgs": [],
+        "flox-floxpkgs": [
+          "etc-profiles",
+          "ld-floxlib",
+          "flox-floxpkgs"
+        ],
         "nixpkgs": [
+          "etc-profiles",
+          "ld-floxlib",
+          "flox-floxpkgs",
           "nixpkgs",
           "nixpkgs-stable"
         ],
@@ -315,11 +831,11 @@
         "nixpkgs__flox__x86_64-linux": "nixpkgs__flox__x86_64-linux"
       },
       "locked": {
-        "lastModified": 1686683972,
-        "narHash": "sha256-rvx7b5ZUkQL0hjy7mwIoiZ+7TAKkoCejxYurVARmTyk=",
+        "lastModified": 1686770319,
+        "narHash": "sha256-9ffqbrKUa0g2aql8B8SDXTCDzyU8PnW7JI1uisuk0dQ=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "49b3ed2aa83d6458453ee7321742b6ee149d581a",
+        "rev": "48e8d0cfdc7bc98e9bf4d65a67ea324b3d952ea7",
         "type": "github"
       },
       "original": {
@@ -328,15 +844,80 @@
         "type": "github"
       }
     },
+    "nixpkgs_7": {
+      "locked": {
+        "lastModified": 1685714850,
+        "narHash": "sha256-OcvbIJq4CGwwFr9m7M/SQcDPZ64hhR4t77oZgEeh7ZY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c6ffce3d5df7b4c588ce80a0c6e2d2348a611707",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_8": {
+      "locked": {
+        "lastModified": 1674236650,
+        "narHash": "sha256-B4GKL1YdJnII6DQNNJ4wDW1ySJVx2suB1h/v4Ql8J0Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cfb43ad7b941d9c3606fb35d91228da7ebddbfc5",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1685866647,
+        "narHash": "sha256-4jKguNHY/edLYImB+uL8jKPL/vpfOvMmSlLAGfxSrnY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a53a3bec10deef6e1cc1caba5bc60f53b959b1e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs__flox__aarch64-darwin": {
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1686683540,
-        "narHash": "sha256-VNgYsghKAxeGbXdTN9R8zYIxzRhWrpFzzyw6agTcobY=",
+        "lastModified": 1686769905,
+        "narHash": "sha256-3bTAKno+hbVkaj/7nIuG8CgBuS347E6ksPcwwjcMw78=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "47c44b1eee4760dfa1aafe8517a35d876fe22614",
+        "rev": "7800311cb0d5c8970021f9f6691115feb0be7c04",
+        "type": "github"
+      },
+      "original": {
+        "host": "catalog.floxsdlc.com",
+        "owner": "flox",
+        "ref": "aarch64-darwin",
+        "repo": "nixpkgs-flox",
+        "type": "github"
+      }
+    },
+    "nixpkgs__flox__aarch64-darwin_2": {
+      "flake": false,
+      "locked": {
+        "host": "catalog.floxsdlc.com",
+        "lastModified": 1686769905,
+        "narHash": "sha256-3bTAKno+hbVkaj/7nIuG8CgBuS347E6ksPcwwjcMw78=",
+        "owner": "flox",
+        "repo": "nixpkgs-flox",
+        "rev": "7800311cb0d5c8970021f9f6691115feb0be7c04",
         "type": "github"
       },
       "original": {
@@ -351,11 +932,30 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1686683514,
-        "narHash": "sha256-QmAjfxs27ia1/nViAdgLVbF+MHnljTZsllLwrNyBKX0=",
+        "lastModified": 1686769880,
+        "narHash": "sha256-t5LMiPoNgzB6UKBvUzMlsC3vcYvKoWT6InPHpTf6QNo=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "6089499d6a508308036f56d8940e72c066747d4d",
+        "rev": "234e8b5adf58fe3b1b6a33680f0a6ba8d8b639d0",
+        "type": "github"
+      },
+      "original": {
+        "host": "catalog.floxsdlc.com",
+        "owner": "flox",
+        "ref": "aarch64-linux",
+        "repo": "nixpkgs-flox",
+        "type": "github"
+      }
+    },
+    "nixpkgs__flox__aarch64-linux_2": {
+      "flake": false,
+      "locked": {
+        "host": "catalog.floxsdlc.com",
+        "lastModified": 1686769880,
+        "narHash": "sha256-t5LMiPoNgzB6UKBvUzMlsC3vcYvKoWT6InPHpTf6QNo=",
+        "owner": "flox",
+        "repo": "nixpkgs-flox",
+        "rev": "234e8b5adf58fe3b1b6a33680f0a6ba8d8b639d0",
         "type": "github"
       },
       "original": {
@@ -370,11 +970,30 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1686683899,
-        "narHash": "sha256-zwTpXt27SgY9xdqj8DXgP6//HuR9HC8jmyiJdxgbKTU=",
+        "lastModified": 1686770241,
+        "narHash": "sha256-2EJ6vCG+iMklp4mcUGhZPJk7brx2fHn2fHUYKjtJI34=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "f94744d74853979b28cba70d42716d8904df45e1",
+        "rev": "cd8107202cd66d4047d2f1decb29cf03ad6195cd",
+        "type": "github"
+      },
+      "original": {
+        "host": "catalog.floxsdlc.com",
+        "owner": "flox",
+        "ref": "i686-linux",
+        "repo": "nixpkgs-flox",
+        "type": "github"
+      }
+    },
+    "nixpkgs__flox__i686-linux_2": {
+      "flake": false,
+      "locked": {
+        "host": "catalog.floxsdlc.com",
+        "lastModified": 1686770241,
+        "narHash": "sha256-2EJ6vCG+iMklp4mcUGhZPJk7brx2fHn2fHUYKjtJI34=",
+        "owner": "flox",
+        "repo": "nixpkgs-flox",
+        "rev": "cd8107202cd66d4047d2f1decb29cf03ad6195cd",
         "type": "github"
       },
       "original": {
@@ -389,11 +1008,30 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1686683890,
-        "narHash": "sha256-oJpYv0E8mqaCSncAQbDBWlON/bEUjmYUVkfyDJxZhgs=",
+        "lastModified": 1686770232,
+        "narHash": "sha256-DFuwK3Vul8z9va99vpcWmz32WBv4Hd5tIT/qWdkG/bo=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "663256af62acee73899efa2f7fcadc383252f235",
+        "rev": "21a6177aae1307aaabc94cacff8f729495fa9df0",
+        "type": "github"
+      },
+      "original": {
+        "host": "catalog.floxsdlc.com",
+        "owner": "flox",
+        "ref": "x86_64-darwin",
+        "repo": "nixpkgs-flox",
+        "type": "github"
+      }
+    },
+    "nixpkgs__flox__x86_64-darwin_2": {
+      "flake": false,
+      "locked": {
+        "host": "catalog.floxsdlc.com",
+        "lastModified": 1686770232,
+        "narHash": "sha256-DFuwK3Vul8z9va99vpcWmz32WBv4Hd5tIT/qWdkG/bo=",
+        "owner": "flox",
+        "repo": "nixpkgs-flox",
+        "rev": "21a6177aae1307aaabc94cacff8f729495fa9df0",
         "type": "github"
       },
       "original": {
@@ -408,11 +1046,30 @@
       "flake": false,
       "locked": {
         "host": "catalog.floxsdlc.com",
-        "lastModified": 1686683869,
-        "narHash": "sha256-Jgjnv+NkOiImxO0I5urh1YLSa31Mm99RLCM10MYRnfA=",
+        "lastModified": 1686770212,
+        "narHash": "sha256-Nf8RF6JYjlw65DvBQfkEz2Ev6UFyCM38oPJEIXKNfXc=",
         "owner": "flox",
         "repo": "nixpkgs-flox",
-        "rev": "272f3162f68a1455886e0da096f8cb5b37a3280a",
+        "rev": "209643b52be208bca6eae3a8df22a2e9ea8c175f",
+        "type": "github"
+      },
+      "original": {
+        "host": "catalog.floxsdlc.com",
+        "owner": "flox",
+        "ref": "x86_64-linux",
+        "repo": "nixpkgs-flox",
+        "type": "github"
+      }
+    },
+    "nixpkgs__flox__x86_64-linux_2": {
+      "flake": false,
+      "locked": {
+        "host": "catalog.floxsdlc.com",
+        "lastModified": 1686770212,
+        "narHash": "sha256-Nf8RF6JYjlw65DvBQfkEz2Ev6UFyCM38oPJEIXKNfXc=",
+        "owner": "flox",
+        "repo": "nixpkgs-flox",
+        "rev": "209643b52be208bca6eae3a8df22a2e9ea8c175f",
         "type": "github"
       },
       "original": {
@@ -427,25 +1084,86 @@
       "inputs": {
         "builtfilter": "builtfilter",
         "capacitor": "capacitor",
-        "flox": "flox",
-        "nixpkgs": "nixpkgs_4",
-        "tracelinks": "tracelinks"
+        "etc-profiles": "etc-profiles",
+        "flox": "flox_2",
+        "nixpkgs": "nixpkgs_10",
+        "tracelinks": "tracelinks_2"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "etc-profiles",
+          "ld-floxlib",
+          "flox-floxpkgs",
+          "flox",
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "etc-profiles",
+          "ld-floxlib",
+          "flox-floxpkgs",
+          "flox",
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1685759304,
+        "narHash": "sha256-I3YBH6MS3G5kGzNuc1G0f9uYfTcNY9NYoRc3QsykLk4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c535b4f3327910c96dcf21851bbdd074d0760290",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_2": {
+      "inputs": {
+        "flake-utils": [
+          "flox",
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "flox",
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1685759304,
+        "narHash": "sha256-I3YBH6MS3G5kGzNuc1G0f9uYfTcNY9NYoRc3QsykLk4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c535b4f3327910c96dcf21851bbdd074d0760290",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "shellHooks": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_5",
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1685361114,
-        "narHash": "sha256-4RjrlSb+OO+e1nzTExKW58o3WRwVGpXwj97iCta8aj4=",
+        "lastModified": 1686668298,
+        "narHash": "sha256-AADh9NqHh6X2LOem4BvI7oCkMm+JPCSCE7iIw5nn0VA=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "ca2fdbf3edda2a38140184da6381d49f8206eaf4",
+        "rev": "5b6b54d3f722aa95cbf4ddbe35390a0af8c0015a",
         "type": "github"
       },
       "original": {
@@ -454,7 +1172,112 @@
         "type": "github"
       }
     },
+    "shellHooks_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_4",
+        "flake-utils": "flake-utils_4",
+        "gitignore": "gitignore_2",
+        "nixpkgs": "nixpkgs_9",
+        "nixpkgs-stable": "nixpkgs-stable_3"
+      },
+      "locked": {
+        "lastModified": 1686668298,
+        "narHash": "sha256-AADh9NqHh6X2LOem4BvI7oCkMm+JPCSCE7iIw5nn0VA=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "5b6b54d3f722aa95cbf4ddbe35390a0af8c0015a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "tracelinks": {
+      "inputs": {
+        "flox-floxpkgs": [
+          "etc-profiles",
+          "ld-floxlib",
+          "flox-floxpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1683889723,
+        "narHash": "sha256-h7LMr8tgu4RJecin4oEO50WoTU0rTomAW9+7AJroX0Y=",
+        "ref": "main",
+        "rev": "e05561bdd0ed9d10c66e35a1d8e66defab949534",
+        "revCount": 11,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/tracelinks"
+      },
+      "original": {
+        "ref": "main",
+        "type": "git",
+        "url": "ssh://git@github.com/flox/tracelinks"
+      }
+    },
+    "tracelinks_2": {
       "inputs": {
         "flox-floxpkgs": []
       },

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
   inputs.builtfilter.url = "github:flox/builtfilter?ref=builtfilter-rs";
   inputs.builtfilter.inputs.flox-floxpkgs.follows = "";
 
-  inputs.etc-profiles.url = "git+ssh://git@github.com/flox/etc-profiles?ref=brantley";
+  inputs.etc-profiles.url = "github:flox/etc-profiles";
   inputs.etc-profiles.inputs.flox-floxpkgs.follows = "";
   # ===========================================================================
 

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,9 @@
 
   inputs.builtfilter.url = "github:flox/builtfilter?ref=builtfilter-rs";
   inputs.builtfilter.inputs.flox-floxpkgs.follows = "";
+
+  inputs.etc-profiles.url = "git+ssh://git@github.com/flox/etc-profiles?ref=brantley";
+  inputs.etc-profiles.inputs.flox-floxpkgs.follows = "";
   # ===========================================================================
 
   outputs = args @ {capacitor, ...}: capacitor args (

--- a/lib/buildenv/README.flox
+++ b/lib/buildenv/README.flox
@@ -1,0 +1,2 @@
+The files in this directory are copied from nixpkgs:pkgs/build-support/buildenv
+with minimal modifications as denoted by the <flox> </flox> comment delimiters.

--- a/lib/buildenv/builder.pl
+++ b/lib/buildenv/builder.pl
@@ -1,0 +1,303 @@
+#! @perl@ -w
+
+use strict;
+use Cwd 'abs_path';
+use IO::Handle;
+use File::Path;
+use File::Basename;
+use File::Compare;
+use JSON::PP;
+
+STDOUT->autoflush(1);
+
+$SIG{__WARN__} = sub { warn "warning: ", @_ };
+$SIG{__DIE__}  = sub { die "error: ", @_ };
+
+my $out = $ENV{"out"};
+my $extraPrefix = $ENV{"extraPrefix"};
+
+my @pathsToLink = split ' ', $ENV{"pathsToLink"};
+
+sub isInPathsToLink {
+    my $path = shift;
+    $path = "/" if $path eq "";
+    foreach my $elem (@pathsToLink) {
+        return 1 if
+            $elem eq "/" ||
+            (substr($path, 0, length($elem)) eq $elem
+             && (($path eq $elem) || (substr($path, length($elem), 1) eq "/")));
+    }
+    return 0;
+}
+
+# Returns whether a path in one of the linked packages may contain
+# files in one of the elements of pathsToLink.
+sub hasPathsToLink {
+    my $path = shift;
+    foreach my $elem (@pathsToLink) {
+        return 1 if
+            $path eq "" ||
+            (substr($elem, 0, length($path)) eq $path
+             && (($path eq $elem) || (substr($elem, length($path), 1) eq "/")));
+    }
+    return 0;
+}
+
+# Similar to `lib.isStorePath`
+sub isStorePath {
+    my $path = shift;
+    my $storePath = "@storeDir@";
+
+    return substr($path, 0, 1) eq "/" && dirname($path) eq $storePath;
+}
+
+# For each activated package, determine what symlinks to create.
+
+my %symlinks;
+
+# Add all pathsToLink and all parent directories.
+#
+# For "/a/b/c" that will include
+# [ "", "/a", "/a/b", "/a/b/c" ]
+#
+# That ensures the whole directory tree needed by pathsToLink is
+# created as directories and not symlinks.
+$symlinks{""} = ["", 0];
+for my $p (@pathsToLink) {
+    my @parts = split '/', $p;
+
+    my $cur = "";
+    for my $x (@parts) {
+        $cur = $cur . "/$x";
+        $cur = "" if $cur eq "/";
+        $symlinks{$cur} = ["", 0];
+    }
+}
+
+sub findFiles;
+
+sub findFilesInDir {
+    my ($relName, $target, $ignoreCollisions, $checkCollisionContents, $priority) = @_;
+
+    opendir DIR, "$target" or die "cannot open `$target': $!";
+    my @names = readdir DIR or die;
+    closedir DIR;
+
+    foreach my $name (@names) {
+        next if $name eq "." || $name eq "..";
+        findFiles("$relName/$name", "$target/$name", $name, $ignoreCollisions, $checkCollisionContents, $priority);
+    }
+}
+
+sub checkCollision {
+    my ($path1, $path2) = @_;
+
+    if (! -e $path1 || ! -e $path2) {
+        return 0;
+    }
+
+    my $stat1 = (stat($path1))[2];
+    my $stat2 = (stat($path2))[2];
+
+    if ($stat1 != $stat2) {
+        warn "different permissions in `$path1' and `$path2': "
+           . sprintf("%04o", $stat1 & 07777) . " <-> "
+           . sprintf("%04o", $stat2 & 07777);
+        return 0;
+    }
+
+    return compare($path1, $path2) == 0;
+}
+
+sub prependDangling {
+    my $path = shift;
+    return (-l $path && ! -e $path ? "dangling symlink " : "") . "`$path'";
+}
+
+sub findFiles {
+    my ($relName, $target, $baseName, $ignoreCollisions, $checkCollisionContents, $priority) = @_;
+
+    # The store path must not be a file
+    if (-f $target && isStorePath $target) {
+        die "The store path $target is a file and can't be merged into an environment using pkgs.buildEnv!";
+    }
+
+    # Urgh, hacky...
+    return if
+        $relName eq "/propagated-build-inputs" ||
+        $relName eq "/nix-support" ||
+        $relName =~ /info\/dir/ ||
+        ( $relName =~ /^\/share\/mime\// && !( $relName =~ /^\/share\/mime\/packages/ ) ) ||
+        $baseName eq "perllocal.pod" ||
+        $baseName eq "log" ||
+        ! (hasPathsToLink($relName) || isInPathsToLink($relName));
+
+    my ($oldTarget, $oldPriority) = @{$symlinks{$relName} // [undef, undef]};
+
+    # If target doesn't exist, create it. If it already exists as a
+    # symlink to a file (not a directory) in a lower-priority package,
+    # overwrite it.
+    if (!defined $oldTarget || ($priority < $oldPriority && ($oldTarget ne "" && ! -d $oldTarget))) {
+        # If target is a dangling symlink, emit a warning.
+        if (-l $target && ! -e $target) {
+            my $link = readlink $target;
+            warn "creating dangling symlink `$out$extraPrefix/$relName' -> `$target' -> `$link'\n";
+        }
+        $symlinks{$relName} = [$target, $priority];
+        return;
+    }
+
+    # If target already exists and both targets resolves to the same path, skip
+    if (
+        defined $oldTarget && $oldTarget ne "" &&
+        defined abs_path($target) && defined abs_path($oldTarget) &&
+        abs_path($target) eq abs_path($oldTarget)
+    ) {
+        # Prefer the target that is not a symlink, if any
+        if (-l $oldTarget && ! -l $target) {
+            $symlinks{$relName} = [$target, $priority];
+        }
+        return;
+    }
+
+    # If target already exists as a symlink to a file (not a
+    # directory) in a higher-priority package, skip.
+    if (defined $oldTarget && $priority > $oldPriority && $oldTarget ne "" && ! -d $oldTarget) {
+        return;
+    }
+
+    # If target is supposed to be a directory but it isn't, die with an error message
+    # instead of attempting to recurse into it, only to fail then.
+    # This happens e.g. when pathsToLink contains a non-directory path.
+    if ($oldTarget eq "" && ! -d $target) {
+        die "not a directory: `$target'\n";
+    }
+
+    unless (-d $target && ($oldTarget eq "" || -d $oldTarget)) {
+        # Prepend "dangling symlink" to paths if applicable.
+        my $targetRef = prependDangling($target);
+        my $oldTargetRef = prependDangling($oldTarget);
+
+        if ($ignoreCollisions) {
+            warn "collision between $targetRef and $oldTargetRef\n" if $ignoreCollisions == 1;
+            return;
+        } elsif ($checkCollisionContents && checkCollision($oldTarget, $target)) {
+            return;
+        } else {
+            die "collision between $targetRef and $oldTargetRef\n";
+        }
+    }
+
+    findFilesInDir($relName, $oldTarget, $ignoreCollisions, $checkCollisionContents, $oldPriority) unless $oldTarget eq "";
+    findFilesInDir($relName, $target, $ignoreCollisions, $checkCollisionContents, $priority);
+
+    $symlinks{$relName} = ["", $priority]; # denotes directory
+}
+
+
+my %done;
+my %postponed;
+
+sub addPkg {
+    my ($pkgDir, $ignoreCollisions, $checkCollisionContents, $priority)  = @_;
+
+    return if (defined $done{$pkgDir});
+    $done{$pkgDir} = 1;
+
+    findFiles("", $pkgDir, "", $ignoreCollisions, $checkCollisionContents, $priority);
+
+    # <flox>
+    #
+    #   When rendering floxEnvs treat propagated-build-inputs as if they
+    #   were propagated-user-env-packages so that required packages already
+    #   present in the closure can be found from the one environment path.
+    #   This is particularly relevant for interpreted languages like python
+    #   that can then use a single value for PYTHONPATH rather than having
+    #   to rely upon walking setup hooks for constructing a long PYTHONPATH
+    #   during a potentially-unbounded instantiation.
+    #
+    # my $propagatedFN = "$pkgDir/nix-support/propagated-user-env-packages";
+    foreach my $propagatedFN (
+        "$pkgDir/nix-support/propagated-user-env-packages", "$pkgDir/nix-support/propagated-build-inputs"
+    ) {
+    # </flox>
+
+    if (-e $propagatedFN) {
+        open PROP, "<$propagatedFN" or die;
+        my $propagated = <PROP>;
+        close PROP;
+        my @propagated = split ' ', $propagated;
+        foreach my $p (@propagated) {
+            $postponed{$p} = 1 unless defined $done{$p};
+        }
+    }
+
+    # <flox>
+    }
+    # </flox>
+
+}
+
+# Read packages list.
+my $pkgs;
+
+if (exists $ENV{"pkgsPath"}) {
+    open FILE, $ENV{"pkgsPath"};
+    $pkgs = <FILE>;
+    close FILE;
+} else {
+    $pkgs = $ENV{"pkgs"}
+}
+
+# Symlink to the packages that have been installed explicitly by the
+# user.
+for my $pkg (@{decode_json $pkgs}) {
+    for my $path (@{$pkg->{paths}}) {
+        addPkg($path,
+               $ENV{"ignoreCollisions"} eq "1",
+               $ENV{"checkCollisionContents"} eq "1",
+               $pkg->{priority})
+           if -e $path;
+    }
+}
+
+
+# Symlink to the packages that have been "propagated" by packages
+# installed by the user (i.e., package X declares that it wants Y
+# installed as well).  We do these later because they have a lower
+# priority in case of collisions.
+my $priorityCounter = 1000; # don't care about collisions
+while (scalar(keys %postponed) > 0) {
+    my @pkgDirs = keys %postponed;
+    %postponed = ();
+    foreach my $pkgDir (sort @pkgDirs) {
+        addPkg($pkgDir, 2, $ENV{"checkCollisionContents"} eq "1", $priorityCounter++);
+    }
+}
+
+
+# Create the symlinks.
+my $nrLinks = 0;
+foreach my $relName (sort keys %symlinks) {
+    my ($target, $priority) = @{$symlinks{$relName}};
+    my $abs = "$out" . "$extraPrefix" . "/$relName";
+    next unless isInPathsToLink $relName;
+    if ($target eq "") {
+        #print "creating directory $relName\n";
+        mkpath $abs or die "cannot create directory `$abs': $!";
+    } else {
+        #print "creating symlink $relName to $target\n";
+        symlink $target, $abs ||
+            die "error creating link `$abs': $!";
+        $nrLinks++;
+    }
+}
+
+
+print STDERR "created $nrLinks symlinks in user environment\n";
+
+
+my $manifest = $ENV{"manifest"};
+if ($manifest) {
+    symlink($manifest, "$out/manifest") or die "cannot create manifest";
+}

--- a/lib/buildenv/default.nix
+++ b/lib/buildenv/default.nix
@@ -2,14 +2,15 @@
 # a fork of the buildEnv in the Nix distribution.  Most changes should
 # eventually be merged back into the Nix distribution.
 
+# <flox>
 # capacitor API
 # `lib` recipes are system independent hence we must provide `pkgs` explicitly
 { lib }:
 pkgs:
-let 
+let
   inherit (pkgs) buildPackages runCommand substituteAll;
 in
-
+# </flox>
 
 lib.makeOverridable
 ({ name

--- a/lib/buildenv/default.nix
+++ b/lib/buildenv/default.nix
@@ -1,0 +1,84 @@
+# buildEnv creates a tree of symlinks to the specified paths.  This is
+# a fork of the buildEnv in the Nix distribution.  Most changes should
+# eventually be merged back into the Nix distribution.
+
+{ buildPackages, runCommand, lib, substituteAll }:
+
+lib.makeOverridable
+({ name
+
+, # The manifest file (if any).  A symlink $out/manifest will be
+  # created to it.
+  manifest ? ""
+
+, # The paths to symlink.
+  paths
+
+, # Whether to ignore collisions or abort.
+  ignoreCollisions ? false
+
+, # If there is a collision, check whether the contents and permissions match
+  # and only if not, throw a collision error.
+  checkCollisionContents ? true
+
+, # The paths (relative to each element of `paths') that we want to
+  # symlink (e.g., ["/bin"]).  Any file not inside any of the
+  # directories in the list is not symlinked.
+  pathsToLink ? ["/"]
+
+, # The package outputs to include. By default, only the default
+  # output is included.
+  extraOutputsToInstall ? []
+
+, # Root the result in directory "$out${extraPrefix}", e.g. "/share".
+  extraPrefix ? ""
+
+, # Shell commands to run after building the symlink tree.
+  postBuild ? ""
+
+# Additional inputs
+, nativeBuildInputs ? [] # Handy e.g. if using makeWrapper in `postBuild`.
+, buildInputs ? []
+
+, passthru ? {}
+, meta ? {}
+}:
+
+let
+  builder = substituteAll {
+    src = ./builder.pl;
+    inherit (builtins) storeDir;
+  };
+in
+
+runCommand name
+  rec {
+    inherit manifest ignoreCollisions checkCollisionContents passthru
+            meta pathsToLink extraPrefix postBuild
+            nativeBuildInputs buildInputs;
+    pkgs = builtins.toJSON (map (drv: {
+      paths =
+        # First add the usual output(s): respect if user has chosen explicitly,
+        # and otherwise use `meta.outputsToInstall`. The attribute is guaranteed
+        # to exist in mkDerivation-created cases. The other cases (e.g. runCommand)
+        # aren't expected to have multiple outputs.
+        (if (! drv ? outputSpecified || ! drv.outputSpecified)
+            && drv.meta.outputsToInstall or null != null
+          then map (outName: drv.${outName}) drv.meta.outputsToInstall
+          else [ drv ])
+        # Add any extra outputs specified by the caller of `buildEnv`.
+        ++ lib.filter (p: p!=null)
+          (builtins.map (outName: drv.${outName} or null) extraOutputsToInstall);
+      priority = drv.meta.priority or 5;
+    }) paths);
+    preferLocalBuild = true;
+    allowSubstitutes = false;
+    # XXX: The size is somewhat arbitrary
+    passAsFile = if builtins.stringLength pkgs >= 128*1024 then [ "pkgs" ] else [ ];
+  }
+  ''
+    set -x
+    ${buildPackages.perl}/bin/perl -w ${builder}
+    set +x
+    eval "$postBuild"
+  '')

--- a/lib/buildenv/default.nix
+++ b/lib/buildenv/default.nix
@@ -2,7 +2,14 @@
 # a fork of the buildEnv in the Nix distribution.  Most changes should
 # eventually be merged back into the Nix distribution.
 
-{ buildPackages, runCommand, lib, substituteAll }:
+# capacitor API
+# `lib` recipes are system independent hence we must provide `pkgs` explicitly
+{ lib }:
+pkgs:
+let 
+  inherit (pkgs) buildPackages runCommand substituteAll;
+in
+
 
 lib.makeOverridable
 ({ name

--- a/lib/mkEnv.nix
+++ b/lib/mkEnv.nix
@@ -101,8 +101,8 @@ let
           # TODO: get the primary output from the [ordered] eval.outputs
           lib.concatMapStringsSep " " (x: x.meta.publishData.eval.outputs.out) (
             builtins.filter (
-	      x: lib.hasAttrByPath [ "meta" "publishData" "eval" "outputs" "out" ] x
-	    ) args.packages
+              x: lib.hasAttrByPath [ "meta" "publishData" "eval" "outputs" "out" ] x
+            ) args.packages
           )
         } > $out/nix-support/propagated-user-env-packages"
       ];

--- a/lib/mkEnv.nix
+++ b/lib/mkEnv.nix
@@ -87,24 +87,31 @@ let
       version = 2;
     };
     manifestFile = builtins.toFile "profile" manifestJSON;
+
+    # TODO: get the primary output from the [ordered] eval.outputs
+    propagatedPackages = lib.concatMapStringsSep " " (x:
+      x.meta.publishData.eval.outputs.out) (
+        builtins.filter (
+          x: lib.hasAttrByPath [ "meta" "publishData" "eval" "outputs" "out" ] x
+        ) args.packages
+      );
+    buildScript = ''
+      echo ${env};
+      ${coreutils}/bin/mkdir -p $out/nix-support;
+      ${coreutils}/bin/cp ${
+        if manifestPath == null
+          then manifestFile
+          else manifestPath
+      } $out/manifest.json;
+      echo ${propagatedPackages} > $out/nix-support/propagated-user-env-packages;
+    '';
     manifest = derivation {
       name = "profile";
       inherit system;
       builder = "/bin/sh";
       args = [
         "-c"
-        "echo ${env}; ${coreutils}/bin/mkdir -p $out/nix-support; ${coreutils}/bin/cp ${
-          if manifestPath == null
-          then manifestFile
-          else manifestPath
-        } $out/manifest.json; echo ${
-          # TODO: get the primary output from the [ordered] eval.outputs
-          lib.concatMapStringsSep " " (x: x.meta.publishData.eval.outputs.out) (
-            builtins.filter (
-              x: lib.hasAttrByPath [ "meta" "publishData" "eval" "outputs" "out" ] x
-            ) args.packages
-          )
-        } > $out/nix-support/propagated-user-env-packages"
+        buildScript
       ];
     };
 

--- a/lib/mkEnv.nix
+++ b/lib/mkEnv.nix
@@ -38,7 +38,7 @@ let
     bashInteractive
     writeTextFile
     ;
-  buildEnv = callPackage ./buildenv { }; # not actually a package
+  buildEnv = lib.buildenv pkgs;
 
   rest = builtins.removeAttrs args [
     "name"

--- a/pkgs/etc-profiles/default.nix
+++ b/pkgs/etc-profiles/default.nix
@@ -1,0 +1,4 @@
+{
+  capacitated,
+}:
+capacitated.etc-profiles.packages.etc-profiles

--- a/templates/profile/files/flox.nix
+++ b/templates/profile/files/flox.nix
@@ -1,12 +1,8 @@
 {
   # Provides an extensible `<env>/etc/profile` script.
-  packages."github:flox/etc-profiles".profile-base = {};
-  # Sets common environment variables such as `PKG_CONFIG_PATH' and `MANPATH'.
-  packages."github:flox/etc-profiles".profile-common-paths = {};
-  # Sets `PYTHONPATH' if `python3' is detected.
-  packages."github:flox/etc-profiles".profile-python3 = {};
-  # Sets `NODE_PATH' if `node' is detected.
-  packages."github:flox/etc-profiles".profile-node = {};
+  packages."github:flox/etc-profiles".etc-profiles = {
+    meta.outputsToInstall = ["base" "common" "python3" "node"];
+  };
 
   # Adding a package's `dev' output makes it visible to `pkg-config'
   ##packages.nixpkgs-flox.sqlite = {


### PR DESCRIPTION
This patch updates the floxEnv builder to add all packages installed to a flox environment to the nix-support/propagated-user-env-packages file and adds a customized version of the nixpkgs buildEnv builder which recursively treats propagated-{build-inputs,user-env-packages} the same.

The effect of this change is to render symbolic links for all files both in directly installed packages _and_ their (recursive) propagated build input packages, so that files from these inputs can be found in their customary FHS location under $FLOX_ENV, and correspondingly means that $FLOX_ENV can be used in other variables like $PYTHONPATH.

Notably, this does _not_ increase the number of packages in the closure, it only increases the number of symbolic links found in the floxEnv package itself.