### PR TITLE
fix: `etc-profiles` template works and adds various "common packages" by default

### DIFF
--- a/.github/workflows/etc-profiles.yml
+++ b/.github/workflows/etc-profiles.yml
@@ -51,7 +51,7 @@ jobs:
         sed -i -e 's/^}$//' ./flox.nix;
         echo '
           packages.nixpkgs-flox.krb5 = {
-            meta.outputsToInstall = ["bin" "out" "dev"];
+            meta.outputsToInstall = ["out" "dev"];
           };
         }
         ' >> ./flox.nix;

--- a/.github/workflows/etc-profiles.yml
+++ b/.github/workflows/etc-profiles.yml
@@ -40,17 +40,22 @@ jobs:
       run: |
         set -eu;
         set -o pipefail;
-        _ec=0;
-        trap '_ec="$?"; echo "ERROR: code $_ec" >&2; exit "$_ec";' HUP TERM INT;
 
-        mkdir -p ./project;
-        cd ./project;
+        mkdir -p ./krb5-dev;
+        cd ./krb5-dev;
 
         selfURI="github:${{ github.repository }}/${{ github.sha }}";
 
         git init;
-        flox init --template "$selfURI#profile" --name sqlite-dev;
-        sed -i -e 's/##//' -e 's/sqlite/krb5/' -e 's/"bin" //' ./flox.nix;
+        flox init --template "$selfURI#profile" --name krb5-dev;
+        sed -i -e 's/^}$//' ./flox.nix;
+        echo '
+          packages.nixpkgs-flox.krb5 = {
+            meta.outputsToInstall = ["bin" "out" "dev"];
+          };
+        }
+        ' >> ./flox.nix;
+
         echo '---';
         cat ./flox.nix;
         echo '---';

--- a/templates/profile/files/flox.nix
+++ b/templates/profile/files/flox.nix
@@ -1,7 +1,45 @@
 {
-  # Provides an extensible `<env>/etc/profile` script.
+  # A few classics.
+  packages.nixpkgs-flox.coreutils       = {};
+  packages.nixpkgs-flox.findutils       = {};
+  packages.nixpkgs-flox.diffutils       = {};
+  packages.nixpkgs-flox.gnused          = {};
+  packages.nixpkgs-flox.gnugrep         = {};
+  packages.nixpkgs-flox.gawk            = {};
+  packages.nixpkgs-flox.gnutar          = {};
+  packages.nixpkgs-flox.gzip            = {};
+  packages.nixpkgs-flox.bzip2           = {};
+  packages.nixpkgs-flox.gnumake         = {};
+  packages.nixpkgs-flox.bashInteractive = {};
+  packages.nixpkgs-flox.patch           = {};
+  packages.nixpkgs-flox.xz              = {};
+  packages.nixpkgs-flox.file            = {};
+  packages.nixpkgs-flox.jq              = {};
+  packages.nixpkgs-flox.python3         = {};
+  packages.nixpkgs-flox.nodejs          = {};
+  packages.nixpkgs-flox.libtool         = {};
+  packages.nixpkgs-flox.autoconf        = {};
+  packages.nixpkgs-flox.automake        = {};
+  packages.nixpkgs-flox.gnum4           = {};
+  packages.nixpkgs-flox.curl            = {};
+  packages.nixpkgs-flox.wget            = {};
+  packages.nixpkgs-flox.gitFull         = {};
+  packages.nixpkgs-flox.vimHugeX        = {};
+
+  # Get `gcc' on Linux, and LLVM on Darwin
+  inline.packages.cc = { stdenv }: stdenv.cc;
+
   packages."github:flox/etc-profiles".etc-profiles = {
-    meta.outputsToInstall = ["base" "common" "python3" "node"];
+    meta.outputsToInstall = [
+      # Provides an extensible `<env>/etc/profile` script.
+      "base"
+      # Sets common environment vars such as `PKG_CONFIG_PATH' and `MANPATH'.
+      "common"
+      # Sets `PYTHONPATH' if `python3' is detected.
+      "python3"
+      # Sets `NODE_PATH' if `node' is detected.
+      "node"
+    ];
   };
 
   # Adding a package's `dev' output makes it visible to `pkg-config'
@@ -10,6 +48,8 @@
   ##};
 
   shell.hook = ''
+    # If `EDITOR' is undefined, use `vim'.
+    : "''${EDITOR:=vim}";
     # Source `<env>/etc/profile` if it exists.
     [[ -r "$FLOX_ENV/etc/profile" ]] && . "$FLOX_ENV/etc/profile";
   '';

--- a/templates/profile/files/flox.nix
+++ b/templates/profile/files/flox.nix
@@ -56,21 +56,18 @@
 
 
   # Provides an extensible `<env>/etc/profile` script.
-  inline.packages.etc-profiles = { system }: let
-    flake = builtins.getFlake "github:flox/etc-profiles";
-    inherit (flake.packages.${system}) etc-profiles;
-  in etc-profiles // {
-    meta = etc-profiles.meta // {
-      outputsToInstall = [
-        "base"
-        # Sets common environment vars such as `PKG_CONFIG_PATH' and `MANPATH'.
-        "common_paths"
-        # Sets `PYTHONPATH' if `python3' is detected.
-        "python3"
-        # Sets `NODE_PATH' if `node' is detected.
-        "node"
-      ];
-    };
+  packages."github:flox/etc-profiles".etc-profiles = {
+    outputsToInstall = [
+      # Provides a simple `<env>/etc/profile' script that sources
+      # "child" `<env>/etc/profile.d/*.sh' scripts.
+      "out"
+      # Sets common environment vars such as `PKG_CONFIG_PATH' and `MANPATH'.
+      "common_paths"
+      # Sets `PYTHONPATH' if `python3' is detected.
+      "python3"
+      # Sets `NODE_PATH' if `node' is detected.
+      "node"
+    ];
   };
 
   # Grab some development dependencies.

--- a/templates/profile/files/flox.nix
+++ b/templates/profile/files/flox.nix
@@ -1,55 +1,87 @@
 {
   # A few classics.
-  packages.nixpkgs-flox.coreutils       = {};
-  packages.nixpkgs-flox.findutils       = {};
-  packages.nixpkgs-flox.diffutils       = {};
-  packages.nixpkgs-flox.gnused          = {};
-  packages.nixpkgs-flox.gnugrep         = {};
-  packages.nixpkgs-flox.gawk            = {};
-  packages.nixpkgs-flox.gnutar          = {};
-  packages.nixpkgs-flox.gzip            = {};
-  packages.nixpkgs-flox.bzip2           = {};
-  packages.nixpkgs-flox.gnumake         = {};
-  packages.nixpkgs-flox.bashInteractive = {};
-  packages.nixpkgs-flox.patch           = {};
-  packages.nixpkgs-flox.xz              = {};
-  packages.nixpkgs-flox.file            = {};
-  packages.nixpkgs-flox.jq              = {};
-  packages.nixpkgs-flox.python3         = {};
-  packages.nixpkgs-flox.nodejs          = {};
-  packages.nixpkgs-flox.libtool         = {};
-  packages.nixpkgs-flox.autoconf        = {};
-  packages.nixpkgs-flox.automake        = {};
-  packages.nixpkgs-flox.gnum4           = {};
-  packages.nixpkgs-flox.curl            = {};
-  packages.nixpkgs-flox.wget            = {};
-  packages.nixpkgs-flox.gitFull         = {};
-  packages.nixpkgs-flox.vimHugeX        = {};
+  packages.nixpkgs-flox.coreutils = {};
+  packages.nixpkgs-flox.findutils = {};
+  packages.nixpkgs-flox.diffutils = {};
+  packages.nixpkgs-flox.gnused    = {};
+  packages.nixpkgs-flox.gnugrep   = {};
+  packages.nixpkgs-flox.gawk      = {};
+  packages.nixpkgs-flox.patch     = {};
+  packages.nixpkgs-flox.file      = {};
+  packages.nixpkgs-flox.jq        = {};
 
-  # Get `gcc' on Linux, and LLVM on Darwin
+  # Compression
+  packages.nixpkgs-flox.gnutar = {};
+  packages.nixpkgs-flox.xz     = {};
+  packages.nixpkgs-flox.gzip   = {};
+  packages.nixpkgs-flox.bzip2  = {};
+
+  # Scripting
+  packages.nixpkgs-flox.bashInteractive = {};
+  packages.nixpkgs-flox.nodejs-slim     = {};
+  inline.packages.npm                   = { nodejs }: nodejs.pkgs.npm;
+  packages.nixpkgs-flox.python3         = {};
+  inline.packages.pip                   = { python3 }: python3.pkgs.pip;
+
+  # Fetching and Networking
+  packages.nixpkgs-flox.curl    = {};
+  packages.nixpkgs-flox.wget    = {};
+  packages.nixpkgs-flox.gitFull = {};
+  ##packages.nixpkgs-flox.ncat    = {};
+  ##packages.nixpkgs-flox.openssh = {};
+
+  # Build Utils
+  packages.nixpkgs-flox.gnumake  = {};
+  packages.nixpkgs-flox.libtool  = {};
+  packages.nixpkgs-flox.autoconf = {};
+  packages.nixpkgs-flox.automake = {};
+  packages.nixpkgs-flox.gnum4    = {};
+
+  # Compiler Collection
+  # Selects `gcc' on Linux, and LLVM on Darwin.
   inline.packages.cc = { stdenv }: stdenv.cc;
 
-  packages."github:flox/etc-profiles".etc-profiles = {
-    meta.outputsToInstall = [
-      # Provides an extensible `<env>/etc/profile` script.
-      "base"
-      # Sets common environment vars such as `PKG_CONFIG_PATH' and `MANPATH'.
-      "common"
-      # Sets `PYTHONPATH' if `python3' is detected.
-      "python3"
-      # Sets `NODE_PATH' if `node' is detected.
-      "node"
-    ];
+  # Debugging
+  ##packages.nixpkgs-flox.gdb      = {};
+  ##packages.nixpkgs-flox.valgrind = {};
+
+  # Text Editing
+  ##packages.nixpkgs-flox.vimHugeX = {};
+
+  # Interactive Extras
+  ##packages.nixpkgs-flox.zsh             = {};
+  ##packages.nixpkgs-flox.tmux            = {};
+  ##packages.nixpkgs-flox.silver-searcher = {};
+  ##packages.nixpkgs-flox.fzf             = {};
+
+
+  # Provides an extensible `<env>/etc/profile` script.
+  inline.packages.etc-profiles = { system }: let
+    flake = builtins.getFlake "github:flox/etc-profiles";
+    inherit (flake.packages.${system}) etc-profiles;
+  in etc-profiles // {
+    meta = etc-profiles.meta // {
+      outputsToInstall = [
+        "base"
+        # Sets common environment vars such as `PKG_CONFIG_PATH' and `MANPATH'.
+        "common_paths"
+        # Sets `PYTHONPATH' if `python3' is detected.
+        "python3"
+        # Sets `NODE_PATH' if `node' is detected.
+        "node"
+      ];
+    };
   };
 
-  # Adding a package's `dev' output makes it visible to `pkg-config'
+  # Grab some development dependencies.
+  # Adding a package's `dev' output makes it visible to `pkg-config'.
+  # Conventionally `dev' outputs will carry `include/' and `lib/pkgconfig/'
+  # paths required for hacking around.
   ##packages.nixpkgs-flox.sqlite = {
   ##  meta.outputsToInstall = ["bin" "out" "dev"];
   ##};
 
   shell.hook = ''
-    # If `EDITOR' is undefined, use `vim'.
-    : "''${EDITOR:=vim}";
     # Source `<env>/etc/profile` if it exists.
     [[ -r "$FLOX_ENV/etc/profile" ]] && . "$FLOX_ENV/etc/profile";
   '';


### PR DESCRIPTION
Obviously the way we refer to `etc-profiles` is not a long term solution, but this works "today".