### PR TITLE
build: use lazy derivations for flox packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,9 +17,9 @@
 
   # This is needed for `pkgs/flox{,-prerelease}/default.nix` to refer to the capacitated
   # recipe.
-  inputs.flox-latest.url = "git+ssh://git@github.com/flox/flox?ref=latest";
+  inputs.flox-latest.url = "git+https://git@github.com/flox/flox?ref=latest";
   inputs.flox-latest.inputs.flox-floxpkgs.follows = "";
-  inputs.flox-main.url = "git+ssh://git@github.com/flox/flox?ref=main";
+  inputs.flox-main.url = "git+https://git@github.com/flox/flox?ref=main";
   inputs.flox-main.inputs.flox-floxpkgs.follows = "";
   # Several packages rely on flox/floxpkgs having an input called "flox".
   # Add this to refer to the release version by default.

--- a/pkgs/flox-prerelease/default.nix
+++ b/pkgs/flox-prerelease/default.nix
@@ -1,1 +1,31 @@
-{capacitated}: capacitated.flox-main.packages.flox
+/*
+Re-export flox as a "lazy" derivation with an additional attribute `fromCatalog`
+
+Adding an attribute to a canonical re-export such as
+
+    { capacitated }:
+      capacitated.flox-main.packages.flox // {fromCatalog = self.evalCatalog.stable.flox; }
+
+requires the evaluation of `capacitated.flox-main.packages.flox` to an attrset.
+
+We want to allow installin packages from the catalog explicitly without any evaluation of the
+upstream package (which involves fetching any number of additional flakes).
+*/
+
+{
+  self,
+  capacitated,
+  ...
+}:
+{
+  type = "derivation";
+
+  # re-export outputs and derivation attributes to allow building
+  inherit (capacitated.flox-main.packages.flox) outputs out man outPath outputName drvPath name system;
+
+  # re-export metadata
+  meta = capacitated.flox-main.packages.flox.meta;
+
+  # add additional attribute
+  fromCatalog = self.evalCatalog.stable.flox-prerelease;
+}

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -1,1 +1,31 @@
-{capacitated, self}: capacitated.flox-latest.packages.flox // { fromCatalog = self.evalCatalog.stable.flox; }
+/*
+Re-export flox as a "lazy" derivation with an additional attribute `fromCatalog`
+
+Adding an attribute to a canonical re-export such as
+
+    { capacitated }:
+      capacitated.flox-latest.packages.flox // {fromCatalog = self.evalCatalog.stable.flox; }
+
+requires the evaluation of `capacitated.flox-latest.packages.flox` to an attrset.
+
+We want to allow installin packages from the catalog explicitly without any evaluation of the
+upstream package (which involves fetching any number of additional flakes).
+*/
+
+{
+  self,
+  capacitated,
+  ...
+}:
+{
+  type = "derivation";
+
+  # re-export outputs and derivation attributes to allow building
+  inherit (capacitated.flox-latest.packages.flox) outputs out man outPath outputName drvPath name system;
+
+  # re-export metadata
+  meta = capacitated.flox-latest.packages.flox.meta;
+
+  # add additional attribute
+  fromCatalog = self.evalCatalog.stable.flox;
+}

--- a/pkgs/flox/default.nix
+++ b/pkgs/flox/default.nix
@@ -1,1 +1,1 @@
-{capacitated}: capacitated.flox-latest.packages.flox
+{capacitated, self}: capacitated.flox-latest.packages.flox // { fromCatalog = self.evalCatalog.stable.flox; }


### PR DESCRIPTION
Reverting parts of #155 bringing back the "lazy derivations" for flox and flox-prerelease.

Re-export flox as a "lazy" derivation with an additional attribute `fromCatalog`

Adding an attribute to a canonical re-export such as

    { capacitated }:
      capacitated.flox-main.packages.flox // {fromCatalog = self.evalCatalog.stable.flox; }

requires the evaluation of `capacitated.flox-main.packages.flox` to an attrset.

We want to allow installin packages from the catalog explicitly without any evaluation of the
upstream package (which involves fetching any number of additional flakes).