### PR TITLE
fix: eliminate non-existent input warning for etc-profiles

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,6 @@
   inputs.builtfilter.inputs.flox-floxpkgs.follows = "";
 
   inputs.etc-profiles.url = "github:flox/etc-profiles";
-  inputs.etc-profiles.inputs.flox-floxpkgs.follows = "";
   # ===========================================================================
 
   outputs = args @ {capacitor, ...}: capacitor args (


### PR DESCRIPTION
Gets rid of this warning for many invocations of `flox`:
```console
warning: input 'flox-floxpkgs/etc-profiles' has an override for a non-existent input 'flox-floxpkgs'
```
