### PR TITLE
fix: move builtfilter to be over git+ssh

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,16 +7,16 @@
       "locked": {
         "lastModified": 1690396033,
         "narHash": "sha256-Ei0/avjSGJab4MnBEFxBSJwn9A3TAMTtN50p+95tDjw=",
-        "owner": "flox",
-        "repo": "builtfilter",
+        "ref": "builtfilter-rs",
         "rev": "ac4f6510377ebe886d268efd827e7d20c37bce10",
-        "type": "github"
+        "revCount": 23,
+        "type": "git",
+        "url": "ssh://git@github.com/flox/builtfilter"
       },
       "original": {
-        "owner": "flox",
         "ref": "builtfilter-rs",
-        "repo": "builtfilter",
-        "type": "github"
+        "type": "git",
+        "url": "ssh://git@github.com/flox/builtfilter"
       }
     },
     "capacitor": {

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
   inputs.tracelinks.url = "git+ssh://git@github.com/flox/tracelinks?ref=main";
   inputs.tracelinks.inputs.flox-floxpkgs.follows = "";
 
-  inputs.builtfilter.url = "github:flox/builtfilter?ref=builtfilter-rs";
+  inputs.builtfilter.url = "git+ssh://git@github.com/flox/builtfilter?ref=builtfilter-rs";
   inputs.builtfilter.inputs.flox-floxpkgs.follows = "";
 
   inputs.etc-profiles.url = "github:flox/etc-profiles";


### PR DESCRIPTION
builtfilter is a private repo, thus ssh is more reliable to provide access. Is there a CI or other location that expects this to be over "github:"?