### PR TITLE
ci: only trigger lockfile updates on changes to `master`

### DIFF
--- a/.github/workflows/trigger-update.yml
+++ b/.github/workflows/trigger-update.yml
@@ -2,6 +2,8 @@ name: "Trigger Update of floxpkgs/index"
 
 on:
   push:
+     branches:
+      - "master"
      paths-ignore:
       - '/catalog/**'
   workflow_dispatch:


### PR DESCRIPTION
We are triggering lockfile updates on `master` even on changes to PR branches.
This PR adds a filter to only run the update action in for changes to master.